### PR TITLE
itemsのGraphQLの削除とアップデートを実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ dev_appserver.py app.local.yaml
 ## GraphQL スキーマドキュメント
 
 ```
-$ yarn graphql-markdown http://localhost:8080/graphql > schema.md
+$ yarn graphql-markdown http://localhost:8080/query > schema.md
 ```
 
 ## GraphQLスキーマ更新

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -58,6 +58,8 @@ type ComplexityRoot struct {
 	Mutation struct {
 		CreateItem func(childComplexity int, input model.NewItem) int
 		CreateUser func(childComplexity int, input model.NewUser) int
+		DeleteItem func(childComplexity int, input model.DeleteItem) int
+		UpdateItem func(childComplexity int, input model.UpdateItem) int
 	}
 
 	Query struct {
@@ -76,6 +78,8 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.NewUser) (*model.User, error)
 	CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error)
+	UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error)
+	DeleteItem(ctx context.Context, input model.DeleteItem) (*model.Item, error)
 }
 type QueryResolver interface {
 	User(ctx context.Context) (*model.User, error)
@@ -177,6 +181,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateUser(childComplexity, args["input"].(model.NewUser)), true
+
+	case "Mutation.deleteItem":
+		if e.complexity.Mutation.DeleteItem == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteItem_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteItem(childComplexity, args["input"].(model.DeleteItem)), true
+
+	case "Mutation.updateItem":
+		if e.complexity.Mutation.UpdateItem == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateItem_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.UpdateItem(childComplexity, args["input"].(model.UpdateItem)), true
 
 	case "Query.item":
 		if e.complexity.Query.Item == nil {
@@ -349,11 +377,33 @@ input NewItem {
   dislike: Boolean!
 }
 
+input UpdateItem {
+  "アイテムID"
+  id: ID!
+  "タイトル"
+  title: String
+  "カテゴリーID"
+  categoryID: Int
+  "日付"
+  date: Time
+  like: Boolean
+  dislike: Boolean
+}
+
+input DeleteItem {
+  "アイテムID"
+  id: ID!
+}
+
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
+  "アイテムを更新する"
+  updateItem(input: UpdateItem!): Item!
+  "アイテムを削除する"
+  deleteItem(input: DeleteItem!): Item!
 }
 
 scalar Time
@@ -387,6 +437,36 @@ func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, 
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNNewUser2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewUser(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteItem_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.DeleteItem
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNDeleteItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐDeleteItem(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateItem_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.UpdateItem
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNUpdateItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUpdateItem(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -826,6 +906,90 @@ func (ec *executionContext) _Mutation_createItem(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().CreateItem(rctx, args["input"].(model.NewItem))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Item)
+	fc.Result = res
+	return ec.marshalNItem2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐItem(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_updateItem(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_updateItem_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().UpdateItem(rctx, args["input"].(model.UpdateItem))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Item)
+	fc.Result = res
+	return ec.marshalNItem2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐItem(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_deleteItem(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_deleteItem_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteItem(rctx, args["input"].(model.DeleteItem))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2218,6 +2382,26 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputDeleteItem(ctx context.Context, obj interface{}) (model.DeleteItem, error) {
+	var it model.DeleteItem
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNewItem(ctx context.Context, obj interface{}) (model.NewItem, error) {
 	var it model.NewItem
 	var asMap = obj.(map[string]interface{})
@@ -2281,6 +2465,66 @@ func (ec *executionContext) unmarshalInputNewUser(ctx context.Context, obj inter
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
 			it.ID, err = ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateItem(ctx context.Context, obj interface{}) (model.UpdateItem, error) {
+	var it model.UpdateItem
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			it.ID, err = ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "title":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("title"))
+			it.Title, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "categoryID":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("categoryID"))
+			it.CategoryID, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "date":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date"))
+			it.Date, err = ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "like":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("like"))
+			it.Like, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "dislike":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dislike"))
+			it.Dislike, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -2382,6 +2626,16 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "createItem":
 			out.Values[i] = ec._Mutation_createItem(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updateItem":
+			out.Values[i] = ec._Mutation_updateItem(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteItem":
+			out.Values[i] = ec._Mutation_deleteItem(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -2759,6 +3013,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNDeleteItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐDeleteItem(ctx context.Context, v interface{}) (model.DeleteItem, error) {
+	res, err := ec.unmarshalInputDeleteItem(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
 	res, err := graphql.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -2841,6 +3100,11 @@ func (ec *executionContext) marshalNTime2timeᚐTime(ctx context.Context, sel as
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNUpdateItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUpdateItem(ctx context.Context, v interface{}) (model.UpdateItem, error) {
+	res, err := ec.unmarshalInputUpdateItem(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNUser2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v model.User) graphql.Marshaler {
@@ -3110,6 +3374,21 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return graphql.MarshalBoolean(*v)
 }
 
+func (ec *executionContext) unmarshalOInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalInt(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return graphql.MarshalInt(*v)
+}
+
 func (ec *executionContext) marshalOItem2ᚕᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐItem(ctx context.Context, sel ast.SelectionSet, v []*model.Item) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -3179,6 +3458,21 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	return graphql.MarshalString(*v)
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return graphql.MarshalTime(*v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/graph/item.go
+++ b/graph/item.go
@@ -27,6 +27,33 @@ func (g *Graph) CreateItem(ctx context.Context, input *model.NewItem) (*model.It
 	return i, nil
 }
 
+// UpdateItem アイテム更新
+func (g *Graph) UpdateItem(ctx context.Context, input *model.UpdateItem) (*model.Item, error) {
+	i := &model.Item{
+		ID:        input.ID,
+		UpdatedAt: g.Client.Time.Now(),
+	}
+
+	if err := g.App.ItemRepository.Update(ctx, g.FirestoreClient, g.UserID, input, i.UpdatedAt); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
+// DeleteItem アイテム削除
+func (g *Graph) DeleteItem(ctx context.Context, input *model.DeleteItem) (*model.Item, error) {
+	i := &model.Item{
+		ID: input.ID,
+	}
+
+	if err := g.App.ItemRepository.Delete(ctx, g.FirestoreClient, g.UserID, input); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
 // GetItem アイテム取得
 func (g *Graph) GetItem(ctx context.Context, id string) (*model.Item, error) {
 	i, err := g.App.ItemRepository.GetItem(ctx, g.FirestoreClient, g.UserID, id)

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+type DeleteItem struct {
+	// アイテムID
+	ID string `json:"id"`
+}
+
 type Item struct {
 	// アイテムID
 	ID string `json:"id"`
@@ -37,6 +42,19 @@ type NewItem struct {
 type NewUser struct {
 	// ユーザーID
 	ID string `json:"id"`
+}
+
+type UpdateItem struct {
+	// アイテムID
+	ID string `json:"id"`
+	// タイトル
+	Title *string `json:"title"`
+	// カテゴリーID
+	CategoryID *int `json:"categoryID"`
+	// 日付
+	Date    *time.Time `json:"date"`
+	Like    *bool      `json:"like"`
+	Dislike *bool      `json:"dislike"`
 }
 
 type User struct {

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -53,11 +53,33 @@ input NewItem {
   dislike: Boolean!
 }
 
+input UpdateItem {
+  "アイテムID"
+  id: ID!
+  "タイトル"
+  title: String
+  "カテゴリーID"
+  categoryID: Int
+  "日付"
+  date: Time
+  like: Boolean
+  dislike: Boolean
+}
+
+input DeleteItem {
+  "アイテムID"
+  id: ID!
+}
+
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
+  "アイテムを更新する"
+  updateItem(input: UpdateItem!): Item!
+  "アイテムを削除する"
+  deleteItem(input: DeleteItem!): Item!
 }
 
 scalar Time

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -36,6 +36,34 @@ func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) 
 	return result, nil
 }
 
+func (r *mutationResolver) UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.UpdateItem(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *mutationResolver) DeleteItem(ctx context.Context, input model.DeleteItem) (*model.Item, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.DeleteItem(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *queryResolver) User(ctx context.Context) (*model.User, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {

--- a/repository/item.go
+++ b/repository/item.go
@@ -11,6 +11,8 @@ import (
 // UserRepositoryInterface is repository interface
 type ItemRepositoryInterface interface {
 	Create(ctx context.Context, f *firestore.Client, userID string, i *model.Item) error
+	Update(ctx context.Context, f *firestore.Client, userID string, i *model.UpdateItem, updatedAt time.Time) error
+	Delete(ctx context.Context, f *firestore.Client, userID string, i *model.DeleteItem) error
 	GetItem(ctx context.Context, f *firestore.Client, userID string, id string) (*model.Item, error)
 	GetItemsByDate(ctx context.Context, f *firestore.Client, userID string, date time.Time) ([]*model.Item, error)
 }
@@ -38,6 +40,37 @@ func getItemCollection(f *firestore.Client, userID string) *firestore.Collection
 func (re *ItemRepository) Create(ctx context.Context, f *firestore.Client, userID string, i *model.Item) error {
 	_, err := getItemCollection(f, userID).Doc(i.ID).Set(ctx, i)
 
+	return err
+}
+
+// Update アイテムを更新する
+func (re *ItemRepository) Update(ctx context.Context, f *firestore.Client, userID string, i *model.UpdateItem, updatedAt time.Time) error {
+	var u []firestore.Update
+	if i.Title != nil {
+		u = append(u, firestore.Update{Path: "Title", Value: i.Title})
+	}
+	if i.Date != nil {
+		u = append(u, firestore.Update{Path: "Date", Value: i.Date})
+	}
+	if i.CategoryID != nil {
+		u = append(u, firestore.Update{Path: "CategoryID", Value: i.CategoryID})
+	}
+	if i.Like != nil {
+		u = append(u, firestore.Update{Path: "Like", Value: i.Like})
+	}
+	if i.Dislike != nil {
+		u = append(u, firestore.Update{Path: "Dislike", Value: i.Dislike})
+	}
+	u = append(u, firestore.Update{Path: "UpdatedAt", Value: updatedAt})
+
+	_, err := getItemCollection(f, userID).Doc(i.ID).Update(ctx, u)
+
+	return err
+}
+
+// Delete アイテムを削除する
+func (re *ItemRepository) Delete(ctx context.Context, f *firestore.Client, userID string, i *model.DeleteItem) error {
+	_, err := getItemCollection(f, userID).Doc(i.ID).Delete(ctx)
 	return err
 }
 

--- a/schema.md
+++ b/schema.md
@@ -1,3 +1,5 @@
+yarn run v1.22.4
+$ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.bin/graphql-markdown http://localhost:8080/query
 # Schema Types
 
 <details>
@@ -9,8 +11,10 @@
     * [Item](#item)
     * [User](#user)
   * [Inputs](#inputs)
+    * [DeleteItem](#deleteitem)
     * [NewItem](#newitem)
     * [NewUser](#newuser)
+    * [UpdateItem](#updateitem)
   * [Scalars](#scalars)
     * [Boolean](#boolean)
     * [Float](#float)
@@ -109,6 +113,34 @@
 <tr>
 <td colspan="2" align="right" valign="top">input</td>
 <td valign="top"><a href="#newitem">NewItem</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updateItem</strong></td>
+<td valign="top"><a href="#item">Item</a>!</td>
+<td>
+
+アイテムを更新する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#updateitem">UpdateItem</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deleteItem</strong></td>
+<td valign="top"><a href="#item">Item</a>!</td>
+<td>
+
+アイテムを削除する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#deleteitem">DeleteItem</a>!</td>
 <td></td>
 </tr>
 </tbody>
@@ -239,6 +271,29 @@
 
 ## Inputs
 
+### DeleteItem
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+アイテムID
+
+</td>
+</tr>
+</tbody>
+</table>
+
 ### NewItem
 
 <table>
@@ -313,6 +368,66 @@
 </tbody>
 </table>
 
+### UpdateItem
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+アイテムID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>title</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+タイトル
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryID</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+カテゴリーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>date</strong></td>
+<td valign="top"><a href="#time">Time</a></td>
+<td>
+
+日付
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>like</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>dislike</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
 ## Scalars
 
 ### Boolean
@@ -337,4 +452,4 @@ The `String`scalar type represents textual data, represented as UTF-8 character 
 
 ### Time
 
-Done in 1.78s.
+Done in 2.63s.


### PR DESCRIPTION
## 関連 issue

- fixes #9 

## 対応内容
<img width="609" alt="スクリーンショット 2021-03-20 13 00 47" src="https://user-images.githubusercontent.com/19209314/111858437-6d70ef80-897c-11eb-9920-9898ee127e22.png">

 - 以下のMutationを追加
   - **updateItem**: アイテムを更新する
   - **deleteItem**:  アイテムを削除する
 
## 開発用メモ
無し

