### PR TITLE
ページング処理の修正

### DIFF
--- a/graph/item.go
+++ b/graph/item.go
@@ -97,16 +97,14 @@ func (g *Graph) GetItemsInPeriod(ctx context.Context, input model.InputItemsInPe
 	t := g.Client.Time
 
 	cursor := repository.ItemsInPeriodCursor{
-		Date:      time.Now(),
-		CreatedAt: time.Now(),
-		ID:        "",
+		ID:     "",
+		UserID: "",
 	}
 	cursorDate := strings.Split(*input.After, "/")
 	if len(cursorDate) > 1 {
 		cursor = repository.ItemsInPeriodCursor{
-			Date:      t.ParseInLocationTimezone(cursorDate[0]),
-			CreatedAt: t.ParseInLocationTimezone(cursorDate[1]),
-			ID:        cursorDate[2],
+			UserID: cursorDate[0],
+			ID:     cursorDate[1],
 		}
 	}
 
@@ -123,7 +121,7 @@ func (g *Graph) GetItemsInPeriod(ctx context.Context, input model.InputItemsInPe
 
 		ibpes = append(ibpes, &model.ItemsInPeriodEdge{
 			Node:   items[index],
-			Cursor: i.Date.Format("2006-01-02T15:04:05+09:00") + "/" + i.CreatedAt.Format("2006-01-02T15:04:05+09:00") + "/" + i.ID,
+			Cursor: i.UserID + "/" + i.ID,
 		})
 	}
 

--- a/graph/item_test.go
+++ b/graph/item_test.go
@@ -83,6 +83,7 @@ func TestGetItemsInPeriod(t *testing.T) {
 		ID:         "test1",
 		CategoryID: 1,
 		Title:      "test-title",
+		UserID:     "test-user",
 		Date:       date,
 		CreatedAt:  date,
 		UpdatedAt:  date,
@@ -100,11 +101,12 @@ func TestGetItemsInPeriod(t *testing.T) {
 	after := ""
 
 	iipe := []*model.ItemsInPeriodEdge{{
-		Cursor: "2019-01-01T00:00:00+09:00/2019-01-01T00:00:00+09:00/test1",
+		Cursor: "test-user/test1",
 		Node: &model.Item{
 			ID:         "test1",
 			CategoryID: 1,
 			Title:      "test-title",
+			UserID:     "test-user",
 			Date:       date,
 			CreatedAt:  date,
 			UpdatedAt:  date,
@@ -113,7 +115,7 @@ func TestGetItemsInPeriod(t *testing.T) {
 
 	result := &model.ItemsInPeriod{
 		PageInfo: &model.PageInfo{
-			EndCursor:   "2019-01-01T00:00:00+09:00/2019-01-01T00:00:00+09:00/test1",
+			EndCursor:   "test-user/test1",
 			HasNextPage: false,
 		},
 		Edges: iipe,


### PR DESCRIPTION
## 関連 issue

- fixes #17 

## 対応内容
 - StartAfterで指定している値が同じ場合にデータが飛ばされていたので修正
 - StartAfterにSnapshotを設定することで正しいカーソルの指定ができるので、そちらに修正
 
## 開発用メモ
無し

