### PR TITLE
ログイン後のアカウント設定作成 + Firebase Auth実装

### DIFF
--- a/app.go
+++ b/app.go
@@ -24,13 +24,14 @@ func main() {
 
 	router := chi.NewRouter()
 
-	router.Use(auth.NotLoginMiddleware())
-
 	ctx := context.Background()
 	f, err := repository.FirebaseApp(ctx)
 	if err != nil {
 		panic(err)
 	}
+
+	router.Use(auth.NotLoginMiddleware())
+	router.Use(auth.FirebaseLoginMiddleware(f))
 
 	fc, err := f.Firestore(ctx)
 	if err != nil {

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -67,10 +67,11 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateItem func(childComplexity int, input model.NewItem) int
-		CreateUser func(childComplexity int, input model.NewUser) int
-		DeleteItem func(childComplexity int, input model.DeleteItem) int
-		UpdateItem func(childComplexity int, input model.UpdateItem) int
+		CreateAuthUser func(childComplexity int, input model.NewUser) int
+		CreateItem     func(childComplexity int, input model.NewItem) int
+		CreateUser     func(childComplexity int, input model.NewUser) int
+		DeleteItem     func(childComplexity int, input model.DeleteItem) int
+		UpdateItem     func(childComplexity int, input model.UpdateItem) int
 	}
 
 	PageInfo struct {
@@ -95,6 +96,7 @@ type ComplexityRoot struct {
 
 type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.NewUser) (*model.User, error)
+	CreateAuthUser(ctx context.Context, input model.NewUser) (*model.User, error)
 	CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error)
 	UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error)
 	DeleteItem(ctx context.Context, input model.DeleteItem) (*model.Item, error)
@@ -212,6 +214,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ItemsInPeriodEdge.Node(childComplexity), true
+
+	case "Mutation.createAuthUser":
+		if e.complexity.Mutation.CreateAuthUser == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createAuthUser_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateAuthUser(childComplexity, args["input"].(model.NewUser)), true
 
 	case "Mutation.createItem":
 		if e.complexity.Mutation.CreateItem == nil {
@@ -519,6 +533,8 @@ input DeleteItem {
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
+  "認証ユーザーを作成する"
+  createAuthUser(input: NewUser!): User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
   "アイテムを更新する"
@@ -535,6 +551,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_createAuthUser_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.NewUser
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNNewUser2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewUser(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_createItem_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -1187,6 +1218,48 @@ func (ec *executionContext) _Mutation_createUser(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().CreateUser(rctx, args["input"].(model.NewUser))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_createAuthUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createAuthUser_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateAuthUser(rctx, args["input"].(model.NewUser))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3205,6 +3278,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = graphql.MarshalString("Mutation")
 		case "createUser":
 			out.Values[i] = ec._Mutation_createUser(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createAuthUser":
+			out.Values[i] = ec._Mutation_createAuthUser(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graph/index.go
+++ b/graph/index.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cloud.google.com/go/firestore"
 	"github.com/wheatandcat/memoir-backend/auth"
@@ -36,8 +37,11 @@ func NewGraph(ctx context.Context, app *Application, f *firestore.Client) (*Grap
 		if err != nil {
 			return nil, fmt.Errorf("Firebase Auth Invalid")
 		}
+
 		user.ID = u.ID
 	}
+
+	log.Println("UserID:" + user.ID)
 
 	if user.ID == "" {
 		return nil, fmt.Errorf("UserID Invalid")

--- a/graph/index.go
+++ b/graph/index.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"cloud.google.com/go/firestore"
 	"github.com/wheatandcat/memoir-backend/auth"
@@ -40,8 +39,6 @@ func NewGraph(ctx context.Context, app *Application, f *firestore.Client) (*Grap
 
 		user.ID = u.ID
 	}
-
-	log.Println("UserID:" + user.ID)
 
 	if user.ID == "" {
 		return nil, fmt.Errorf("UserID Invalid")

--- a/graph/index.go
+++ b/graph/index.go
@@ -31,7 +31,17 @@ func NewGraph(ctx context.Context, app *Application, f *firestore.Client) (*Grap
 		return nil, fmt.Errorf("Access denied")
 	}
 
-	if user.FirebaseUID != "" {
+	if user.FirebaseUID == "" {
+		// Firebase認証無し
+		u, err := app.UserRepository.FindDatabaseDataByUID(ctx, f, user.ID)
+		if err != nil {
+			return nil, fmt.Errorf("User Invalid")
+		}
+		if u.FirebaseUID != "" {
+			return nil, fmt.Errorf("Need to Firebase Auth")
+		}
+	} else {
+		// Firebase認証有り
 		u, err := app.UserRepository.FindByFirebaseUID(ctx, f, user.FirebaseUID)
 		if err != nil {
 			return nil, fmt.Errorf("Firebase Auth Invalid")

--- a/graph/index.go
+++ b/graph/index.go
@@ -13,6 +13,7 @@ import (
 // Graph Graph struct
 type Graph struct {
 	UserID          string
+	FirebaseUID     string
 	FirestoreClient *firestore.Client
 	App             *Application
 	Client          *Client
@@ -30,12 +31,23 @@ func NewGraph(ctx context.Context, app *Application, f *firestore.Client) (*Grap
 		return nil, fmt.Errorf("Access denied")
 	}
 
+	if user.FirebaseUID != "" {
+		u, err := app.UserRepository.FindByFirebaseUID(ctx, f, user.FirebaseUID)
+		if err != nil {
+			return nil, fmt.Errorf("Firebase Auth Invalid")
+		}
+		user.ID = u.ID
+	}
+
+	if user.ID == "" {
+		return nil, fmt.Errorf("UserID Invalid")
+	}
+
 	return NewGraphWithSetUserID(app, f, user.ID), nil
 }
 
 // NewGraphWithSetUserID Graphを作成（ログイン前）
 func NewGraphWithSetUserID(app *Application, f *firestore.Client, uid string) *Graph {
-
 	client := &Client{
 		UUID: &uuidgen.UUID{},
 		Time: &timegen.Time{},

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -102,6 +102,8 @@ input DeleteItem {
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
+  "認証ユーザーを作成する"
+  createAuthUser(input: NewUser!): User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
   "アイテムを更新する"

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -22,6 +22,16 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) 
 	return result, nil
 }
 
+func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewUser) (*model.User, error) {
+	g := NewGraphWithSetUserID(r.App, r.FirestoreClient, "")
+	result, err := g.CreateAuthUser(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {

--- a/repository/moq.go
+++ b/repository/moq.go
@@ -515,6 +515,9 @@ var _ UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 // 			CreateFunc: func(ctx context.Context, f *firestore.Client, u *model.User) error {
 // 				panic("mock out the Create method")
 // 			},
+// 			ExistByFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, fUID string) (bool, error) {
+// 				panic("mock out the ExistByFirebaseUID method")
+// 			},
 // 			FindByFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error) {
 // 				panic("mock out the FindByFirebaseUID method")
 // 			},
@@ -536,6 +539,9 @@ var _ UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 type UserRepositoryInterfaceMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, f *firestore.Client, u *model.User) error
+
+	// ExistByFirebaseUIDFunc mocks the ExistByFirebaseUID method.
+	ExistByFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, fUID string) (bool, error)
 
 	// FindByFirebaseUIDFunc mocks the FindByFirebaseUID method.
 	FindByFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error)
@@ -559,6 +565,15 @@ type UserRepositoryInterfaceMock struct {
 			F *firestore.Client
 			// U is the u argument value.
 			U *model.User
+		}
+		// ExistByFirebaseUID holds details about calls to the ExistByFirebaseUID method.
+		ExistByFirebaseUID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// FUID is the fUID argument value.
+			FUID string
 		}
 		// FindByFirebaseUID holds details about calls to the FindByFirebaseUID method.
 		FindByFirebaseUID []struct {
@@ -598,6 +613,7 @@ type UserRepositoryInterfaceMock struct {
 		}
 	}
 	lockCreate                sync.RWMutex
+	lockExistByFirebaseUID    sync.RWMutex
 	lockFindByFirebaseUID     sync.RWMutex
 	lockFindByUID             sync.RWMutex
 	lockFindDatabaseDataByUID sync.RWMutex
@@ -640,6 +656,45 @@ func (mock *UserRepositoryInterfaceMock) CreateCalls() []struct {
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create
 	mock.lockCreate.RUnlock()
+	return calls
+}
+
+// ExistByFirebaseUID calls ExistByFirebaseUIDFunc.
+func (mock *UserRepositoryInterfaceMock) ExistByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (bool, error) {
+	if mock.ExistByFirebaseUIDFunc == nil {
+		panic("UserRepositoryInterfaceMock.ExistByFirebaseUIDFunc: method is nil but UserRepositoryInterface.ExistByFirebaseUID was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		FUID string
+	}{
+		Ctx:  ctx,
+		F:    f,
+		FUID: fUID,
+	}
+	mock.lockExistByFirebaseUID.Lock()
+	mock.calls.ExistByFirebaseUID = append(mock.calls.ExistByFirebaseUID, callInfo)
+	mock.lockExistByFirebaseUID.Unlock()
+	return mock.ExistByFirebaseUIDFunc(ctx, f, fUID)
+}
+
+// ExistByFirebaseUIDCalls gets all the calls that were made to ExistByFirebaseUID.
+// Check the length with:
+//     len(mockedUserRepositoryInterface.ExistByFirebaseUIDCalls())
+func (mock *UserRepositoryInterfaceMock) ExistByFirebaseUIDCalls() []struct {
+	Ctx  context.Context
+	F    *firestore.Client
+	FUID string
+} {
+	var calls []struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		FUID string
+	}
+	mock.lockExistByFirebaseUID.RLock()
+	calls = mock.calls.ExistByFirebaseUID
+	mock.lockExistByFirebaseUID.RUnlock()
 	return calls
 }
 

--- a/repository/moq.go
+++ b/repository/moq.go
@@ -515,8 +515,14 @@ var _ UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 // 			CreateFunc: func(ctx context.Context, f *firestore.Client, u *model.User) error {
 // 				panic("mock out the Create method")
 // 			},
+// 			FindByFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error) {
+// 				panic("mock out the FindByFirebaseUID method")
+// 			},
 // 			FindByUIDFunc: func(ctx context.Context, f *firestore.Client, uid string) (*model.User, error) {
 // 				panic("mock out the FindByUID method")
+// 			},
+// 			UpdateFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, user *User) error {
+// 				panic("mock out the UpdateFirebaseUID method")
 // 			},
 // 		}
 //
@@ -528,8 +534,14 @@ type UserRepositoryInterfaceMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, f *firestore.Client, u *model.User) error
 
+	// FindByFirebaseUIDFunc mocks the FindByFirebaseUID method.
+	FindByFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error)
+
 	// FindByUIDFunc mocks the FindByUID method.
 	FindByUIDFunc func(ctx context.Context, f *firestore.Client, uid string) (*model.User, error)
+
+	// UpdateFirebaseUIDFunc mocks the UpdateFirebaseUID method.
+	UpdateFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, user *User) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -542,6 +554,15 @@ type UserRepositoryInterfaceMock struct {
 			// U is the u argument value.
 			U *model.User
 		}
+		// FindByFirebaseUID holds details about calls to the FindByFirebaseUID method.
+		FindByFirebaseUID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// FUID is the fUID argument value.
+			FUID string
+		}
 		// FindByUID holds details about calls to the FindByUID method.
 		FindByUID []struct {
 			// Ctx is the ctx argument value.
@@ -551,9 +572,20 @@ type UserRepositoryInterfaceMock struct {
 			// UID is the uid argument value.
 			UID string
 		}
+		// UpdateFirebaseUID holds details about calls to the UpdateFirebaseUID method.
+		UpdateFirebaseUID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// User is the user argument value.
+			User *User
+		}
 	}
-	lockCreate    sync.RWMutex
-	lockFindByUID sync.RWMutex
+	lockCreate            sync.RWMutex
+	lockFindByFirebaseUID sync.RWMutex
+	lockFindByUID         sync.RWMutex
+	lockUpdateFirebaseUID sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -595,6 +627,45 @@ func (mock *UserRepositoryInterfaceMock) CreateCalls() []struct {
 	return calls
 }
 
+// FindByFirebaseUID calls FindByFirebaseUIDFunc.
+func (mock *UserRepositoryInterfaceMock) FindByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error) {
+	if mock.FindByFirebaseUIDFunc == nil {
+		panic("UserRepositoryInterfaceMock.FindByFirebaseUIDFunc: method is nil but UserRepositoryInterface.FindByFirebaseUID was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		FUID string
+	}{
+		Ctx:  ctx,
+		F:    f,
+		FUID: fUID,
+	}
+	mock.lockFindByFirebaseUID.Lock()
+	mock.calls.FindByFirebaseUID = append(mock.calls.FindByFirebaseUID, callInfo)
+	mock.lockFindByFirebaseUID.Unlock()
+	return mock.FindByFirebaseUIDFunc(ctx, f, fUID)
+}
+
+// FindByFirebaseUIDCalls gets all the calls that were made to FindByFirebaseUID.
+// Check the length with:
+//     len(mockedUserRepositoryInterface.FindByFirebaseUIDCalls())
+func (mock *UserRepositoryInterfaceMock) FindByFirebaseUIDCalls() []struct {
+	Ctx  context.Context
+	F    *firestore.Client
+	FUID string
+} {
+	var calls []struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		FUID string
+	}
+	mock.lockFindByFirebaseUID.RLock()
+	calls = mock.calls.FindByFirebaseUID
+	mock.lockFindByFirebaseUID.RUnlock()
+	return calls
+}
+
 // FindByUID calls FindByUIDFunc.
 func (mock *UserRepositoryInterfaceMock) FindByUID(ctx context.Context, f *firestore.Client, uid string) (*model.User, error) {
 	if mock.FindByUIDFunc == nil {
@@ -631,5 +702,44 @@ func (mock *UserRepositoryInterfaceMock) FindByUIDCalls() []struct {
 	mock.lockFindByUID.RLock()
 	calls = mock.calls.FindByUID
 	mock.lockFindByUID.RUnlock()
+	return calls
+}
+
+// UpdateFirebaseUID calls UpdateFirebaseUIDFunc.
+func (mock *UserRepositoryInterfaceMock) UpdateFirebaseUID(ctx context.Context, f *firestore.Client, user *User) error {
+	if mock.UpdateFirebaseUIDFunc == nil {
+		panic("UserRepositoryInterfaceMock.UpdateFirebaseUIDFunc: method is nil but UserRepositoryInterface.UpdateFirebaseUID was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		User *User
+	}{
+		Ctx:  ctx,
+		F:    f,
+		User: user,
+	}
+	mock.lockUpdateFirebaseUID.Lock()
+	mock.calls.UpdateFirebaseUID = append(mock.calls.UpdateFirebaseUID, callInfo)
+	mock.lockUpdateFirebaseUID.Unlock()
+	return mock.UpdateFirebaseUIDFunc(ctx, f, user)
+}
+
+// UpdateFirebaseUIDCalls gets all the calls that were made to UpdateFirebaseUID.
+// Check the length with:
+//     len(mockedUserRepositoryInterface.UpdateFirebaseUIDCalls())
+func (mock *UserRepositoryInterfaceMock) UpdateFirebaseUIDCalls() []struct {
+	Ctx  context.Context
+	F    *firestore.Client
+	User *User
+} {
+	var calls []struct {
+		Ctx  context.Context
+		F    *firestore.Client
+		User *User
+	}
+	mock.lockUpdateFirebaseUID.RLock()
+	calls = mock.calls.UpdateFirebaseUID
+	mock.lockUpdateFirebaseUID.RUnlock()
 	return calls
 }

--- a/repository/moq.go
+++ b/repository/moq.go
@@ -521,6 +521,9 @@ var _ UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 // 			FindByUIDFunc: func(ctx context.Context, f *firestore.Client, uid string) (*model.User, error) {
 // 				panic("mock out the FindByUID method")
 // 			},
+// 			FindDatabaseDataByUIDFunc: func(ctx context.Context, f *firestore.Client, uid string) (*User, error) {
+// 				panic("mock out the FindDatabaseDataByUID method")
+// 			},
 // 			UpdateFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, user *User) error {
 // 				panic("mock out the UpdateFirebaseUID method")
 // 			},
@@ -539,6 +542,9 @@ type UserRepositoryInterfaceMock struct {
 
 	// FindByUIDFunc mocks the FindByUID method.
 	FindByUIDFunc func(ctx context.Context, f *firestore.Client, uid string) (*model.User, error)
+
+	// FindDatabaseDataByUIDFunc mocks the FindDatabaseDataByUID method.
+	FindDatabaseDataByUIDFunc func(ctx context.Context, f *firestore.Client, uid string) (*User, error)
 
 	// UpdateFirebaseUIDFunc mocks the UpdateFirebaseUID method.
 	UpdateFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, user *User) error
@@ -572,6 +578,15 @@ type UserRepositoryInterfaceMock struct {
 			// UID is the uid argument value.
 			UID string
 		}
+		// FindDatabaseDataByUID holds details about calls to the FindDatabaseDataByUID method.
+		FindDatabaseDataByUID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// UID is the uid argument value.
+			UID string
+		}
 		// UpdateFirebaseUID holds details about calls to the UpdateFirebaseUID method.
 		UpdateFirebaseUID []struct {
 			// Ctx is the ctx argument value.
@@ -582,10 +597,11 @@ type UserRepositoryInterfaceMock struct {
 			User *User
 		}
 	}
-	lockCreate            sync.RWMutex
-	lockFindByFirebaseUID sync.RWMutex
-	lockFindByUID         sync.RWMutex
-	lockUpdateFirebaseUID sync.RWMutex
+	lockCreate                sync.RWMutex
+	lockFindByFirebaseUID     sync.RWMutex
+	lockFindByUID             sync.RWMutex
+	lockFindDatabaseDataByUID sync.RWMutex
+	lockUpdateFirebaseUID     sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -702,6 +718,45 @@ func (mock *UserRepositoryInterfaceMock) FindByUIDCalls() []struct {
 	mock.lockFindByUID.RLock()
 	calls = mock.calls.FindByUID
 	mock.lockFindByUID.RUnlock()
+	return calls
+}
+
+// FindDatabaseDataByUID calls FindDatabaseDataByUIDFunc.
+func (mock *UserRepositoryInterfaceMock) FindDatabaseDataByUID(ctx context.Context, f *firestore.Client, uid string) (*User, error) {
+	if mock.FindDatabaseDataByUIDFunc == nil {
+		panic("UserRepositoryInterfaceMock.FindDatabaseDataByUIDFunc: method is nil but UserRepositoryInterface.FindDatabaseDataByUID was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		F   *firestore.Client
+		UID string
+	}{
+		Ctx: ctx,
+		F:   f,
+		UID: uid,
+	}
+	mock.lockFindDatabaseDataByUID.Lock()
+	mock.calls.FindDatabaseDataByUID = append(mock.calls.FindDatabaseDataByUID, callInfo)
+	mock.lockFindDatabaseDataByUID.Unlock()
+	return mock.FindDatabaseDataByUIDFunc(ctx, f, uid)
+}
+
+// FindDatabaseDataByUIDCalls gets all the calls that were made to FindDatabaseDataByUID.
+// Check the length with:
+//     len(mockedUserRepositoryInterface.FindDatabaseDataByUIDCalls())
+func (mock *UserRepositoryInterfaceMock) FindDatabaseDataByUIDCalls() []struct {
+	Ctx context.Context
+	F   *firestore.Client
+	UID string
+} {
+	var calls []struct {
+		Ctx context.Context
+		F   *firestore.Client
+		UID string
+	}
+	mock.lockFindDatabaseDataByUID.RLock()
+	calls = mock.calls.FindDatabaseDataByUID
+	mock.lockFindDatabaseDataByUID.RUnlock()
 	return calls
 }
 

--- a/repository/user.go
+++ b/repository/user.go
@@ -24,6 +24,7 @@ type UserRepositoryInterface interface {
 	FindByUID(ctx context.Context, f *firestore.Client, uid string) (*model.User, error)
 	FindDatabaseDataByUID(ctx context.Context, f *firestore.Client, uid string) (*User, error)
 	FindByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error)
+	ExistByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (bool, error)
 }
 
 // UserRepository is repository for user
@@ -95,4 +96,16 @@ func (re *UserRepository) FindByFirebaseUID(ctx context.Context, f *firestore.Cl
 	docs[0].DataTo(&u)
 
 	return u, nil
+}
+
+// ExistByFirebaseUID FirebaseユーザーIDが存在するか取得する
+func (re *UserRepository) ExistByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (bool, error) {
+	matchItem := f.Collection("users").Where("FirebaseUID", "==", fUID).OrderBy("CreatedAt", firestore.Asc).Limit(1).Documents(ctx)
+	docs, err := matchItem.GetAll()
+	if err != nil {
+		return false, err
+	}
+
+	return len(docs) > 0, nil
+
 }

--- a/repository/user.go
+++ b/repository/user.go
@@ -73,7 +73,7 @@ func (re *UserRepository) FindByFirebaseUID(ctx context.Context, f *firestore.Cl
 		return nil, err
 	}
 
-	docs[0].DataTo(u)
+	docs[0].DataTo(&u)
 
 	return u, nil
 }

--- a/schema.md
+++ b/schema.md
@@ -134,6 +134,20 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td></td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>createAuthUser</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td>
+
+認証ユーザーを作成する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#newuser">NewUser</a>!</td>
+<td></td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>createItem</strong></td>
 <td valign="top"><a href="#item">Item</a>!</td>
 <td>
@@ -602,4 +616,4 @@ The `String`scalar type represents textual data, represented as UTF-8 character 
 
 ### Time
 
-Done in 2.52s.
+Done in 1.54s.


### PR DESCRIPTION
## 関連 issue

- fixes #21

## 対応内容
 
 - 認証ユーザーを作成する: createAuthUser を作成
 - Firebase AuthenticationのMiddlewareを実装
 - 以下のエラーハンドリングを実装
    - 認証済みの状態で、認証前の認証方法をした場合は エラー
    - 存在しないトークンで認証した場合はエラー
<div>
<img width="680" alt="スクリーンショット 2021-05-01 22 33 04" src="https://user-images.githubusercontent.com/19209314/116784236-22471200-aace-11eb-933f-3bf2087f5e2e.png">
<img width="680" alt="スクリーンショット 2021-05-01 22 33 04" src="https://user-images.githubusercontent.com/19209314/116784302-810c8b80-aace-11eb-9a19-d8a71e21d017.png">
</div>

 - Tokenで取得できるようになったので、別端末でもデータの共有が可能になった
<img width="680" alt="スクリーンショット 2021-05-01 22 27 52" src="https://user-images.githubusercontent.com/19209314/116784285-60443600-aace-11eb-985a-4b539913f8f4.png">

 


## 開発用メモ
無し

