### PR TITLE
共有の承認/拒否 + 共有メンバーの表示/解除を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ go run github.com/99designs/gqlgen generate
 
 ```
 $ rm -rf ./repository/moq.go
-$ moq -out=repository/moq.go ./repository ItemRepositoryInterface UserRepositoryInterface InviteRepositoryInterface RelationshipRequestInterface
+$ moq -out=repository/moq.go ./repository ItemRepositoryInterface UserRepositoryInterface InviteRepositoryInterface RelationshipRequestInterface RelationshipInterface CommonRepositoryInterface
 ```
 
 テストを実行

--- a/graph/common_test.go
+++ b/graph/common_test.go
@@ -16,8 +16,12 @@ func newGraph() graph.Graph {
 	}
 
 	app := &graph.Application{
-		UserRepository: &repository.UserRepositoryInterfaceMock{},
-		ItemRepository: &repository.ItemRepositoryInterfaceMock{},
+		UserRepository:                &repository.UserRepositoryInterfaceMock{},
+		ItemRepository:                &repository.ItemRepositoryInterfaceMock{},
+		InviteRepository:              &repository.InviteRepositoryInterfaceMock{},
+		RelationshipRequestRepository: &repository.RelationshipRequestInterfaceMock{},
+		RelationshipRepository:        &repository.RelationshipInterfaceMock{},
+		CommonRepository:              &repository.CommonRepositoryInterfaceMock{},
 	}
 
 	g := graph.Graph{

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -74,12 +74,15 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		AcceptRelationshipRequest func(childComplexity int, followedID string) int
 		CreateAuthUser            func(childComplexity int, input model.NewUser) int
 		CreateInvite              func(childComplexity int) int
 		CreateItem                func(childComplexity int, input model.NewItem) int
 		CreateRelationshipRequest func(childComplexity int, input model.NewRelationshipRequest) int
 		CreateUser                func(childComplexity int, input model.NewUser) int
 		DeleteItem                func(childComplexity int, input model.DeleteItem) int
+		DeleteRelationship        func(childComplexity int, followedID string) int
+		NgRelationshipRequest     func(childComplexity int, followedID string) int
 		UpdateInvite              func(childComplexity int) int
 		UpdateItem                func(childComplexity int, input model.UpdateItem) int
 		UpdateUser                func(childComplexity int, input model.UpdateUser) int
@@ -98,7 +101,22 @@ type ComplexityRoot struct {
 		ItemsInDate          func(childComplexity int, date time.Time) int
 		ItemsInPeriod        func(childComplexity int, input model.InputItemsInPeriod) int
 		RelationshipRequests func(childComplexity int, input model.InputRelationshipRequests) int
+		Relationships        func(childComplexity int, input model.InputRelationships) int
 		User                 func(childComplexity int) int
+	}
+
+	Relationship struct {
+		CreatedAt  func(childComplexity int) int
+		FollowedID func(childComplexity int) int
+		FollowerID func(childComplexity int) int
+		ID         func(childComplexity int) int
+		UpdatedAt  func(childComplexity int) int
+		User       func(childComplexity int, skip *bool) int
+	}
+
+	RelationshipEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	RelationshipRequest struct {
@@ -117,6 +135,11 @@ type ComplexityRoot struct {
 	}
 
 	RelationshipRequests struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	Relationships struct {
 		Edges    func(childComplexity int) int
 		PageInfo func(childComplexity int) int
 	}
@@ -140,6 +163,9 @@ type MutationResolver interface {
 	CreateInvite(ctx context.Context) (*model.Invite, error)
 	UpdateInvite(ctx context.Context) (*model.Invite, error)
 	CreateRelationshipRequest(ctx context.Context, input model.NewRelationshipRequest) (*model.RelationshipRequest, error)
+	AcceptRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error)
+	NgRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error)
+	DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error)
 }
 type QueryResolver interface {
 	User(ctx context.Context) (*model.User, error)
@@ -150,6 +176,7 @@ type QueryResolver interface {
 	Invite(ctx context.Context) (*model.Invite, error)
 	InviteByCode(ctx context.Context, code string) (*model.User, error)
 	RelationshipRequests(ctx context.Context, input model.InputRelationshipRequests) (*model.RelationshipRequests, error)
+	Relationships(ctx context.Context, input model.InputRelationships) (*model.Relationships, error)
 }
 
 type executableSchema struct {
@@ -286,6 +313,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ItemsInPeriodEdge.Node(childComplexity), true
 
+	case "Mutation.acceptRelationshipRequest":
+		if e.complexity.Mutation.AcceptRelationshipRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_acceptRelationshipRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AcceptRelationshipRequest(childComplexity, args["followedID"].(string)), true
+
 	case "Mutation.createAuthUser":
 		if e.complexity.Mutation.CreateAuthUser == nil {
 			break
@@ -352,6 +391,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteItem(childComplexity, args["input"].(model.DeleteItem)), true
+
+	case "Mutation.deleteRelationship":
+		if e.complexity.Mutation.DeleteRelationship == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteRelationship_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteRelationship(childComplexity, args["followedID"].(string)), true
+
+	case "Mutation.ngRelationshipRequest":
+		if e.complexity.Mutation.NgRelationshipRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_ngRelationshipRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.NgRelationshipRequest(childComplexity, args["followedID"].(string)), true
 
 	case "Mutation.updateInvite":
 		if e.complexity.Mutation.UpdateInvite == nil {
@@ -477,12 +540,85 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.RelationshipRequests(childComplexity, args["input"].(model.InputRelationshipRequests)), true
 
+	case "Query.relationships":
+		if e.complexity.Query.Relationships == nil {
+			break
+		}
+
+		args, err := ec.field_Query_relationships_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Relationships(childComplexity, args["input"].(model.InputRelationships)), true
+
 	case "Query.user":
 		if e.complexity.Query.User == nil {
 			break
 		}
 
 		return e.complexity.Query.User(childComplexity), true
+
+	case "Relationship.createdAt":
+		if e.complexity.Relationship.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Relationship.CreatedAt(childComplexity), true
+
+	case "Relationship.followedId":
+		if e.complexity.Relationship.FollowedID == nil {
+			break
+		}
+
+		return e.complexity.Relationship.FollowedID(childComplexity), true
+
+	case "Relationship.followerId":
+		if e.complexity.Relationship.FollowerID == nil {
+			break
+		}
+
+		return e.complexity.Relationship.FollowerID(childComplexity), true
+
+	case "Relationship.id":
+		if e.complexity.Relationship.ID == nil {
+			break
+		}
+
+		return e.complexity.Relationship.ID(childComplexity), true
+
+	case "Relationship.updatedAt":
+		if e.complexity.Relationship.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Relationship.UpdatedAt(childComplexity), true
+
+	case "Relationship.user":
+		if e.complexity.Relationship.User == nil {
+			break
+		}
+
+		args, err := ec.field_Relationship_user_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Relationship.User(childComplexity, args["skip"].(*bool)), true
+
+	case "RelationshipEdge.cursor":
+		if e.complexity.RelationshipEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.RelationshipEdge.Cursor(childComplexity), true
+
+	case "RelationshipEdge.node":
+		if e.complexity.RelationshipEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.RelationshipEdge.Node(childComplexity), true
 
 	case "RelationshipRequest.createdAt":
 		if e.complexity.RelationshipRequest.CreatedAt == nil {
@@ -565,6 +701,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.RelationshipRequests.PageInfo(childComplexity), true
+
+	case "Relationships.edges":
+		if e.complexity.Relationships.Edges == nil {
+			break
+		}
+
+		return e.complexity.Relationships.Edges(childComplexity), true
+
+	case "Relationships.pageInfo":
+		if e.complexity.Relationships.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.Relationships.PageInfo(childComplexity), true
 
 	case "User.createdAt":
 		if e.complexity.User.CreatedAt == nil {
@@ -766,6 +916,36 @@ input InputRelationshipRequests {
   first: Int!
 }
 
+type Relationship {
+  "ID"
+  id: ID!
+  "フォローしたユーザーID"
+  followerId: String!
+  "フォローされたユーザーID"
+  followedId: String!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+  "ユーザー情報"
+  user(skip: Boolean): User
+}
+
+type RelationshipEdge {
+  node: Relationship
+  cursor: String!
+}
+
+type Relationships {
+  pageInfo: PageInfo!
+  edges: [RelationshipEdge!]!
+}
+
+input InputRelationships {
+  after: String
+  first: Int!
+}
+
 type Query {
   "ユーザーを取得する"
   user: User!
@@ -783,6 +963,8 @@ type Query {
   inviteByCode(code: String!): User!
   "招待の申請リクエストを取得する"
   relationshipRequests(input: InputRelationshipRequests!): RelationshipRequests!
+  "共有ユーザーを取得する"
+  relationships(input: InputRelationships!): Relationships!
 }
 
 input NewUser {
@@ -852,6 +1034,12 @@ type Mutation {
   createRelationshipRequest(
     input: NewRelationshipRequest!
   ): RelationshipRequest!
+  "招待リクエストを承諾する"
+  acceptRelationshipRequest(followedID: String!): RelationshipRequest!
+  "招待リクエストを拒否する"
+  ngRelationshipRequest(followedID: String!): RelationshipRequest!
+  "共有メンバーを解除する"
+  deleteRelationship(followedID: String!): Relationship!
 }
 
 scalar Time
@@ -862,6 +1050,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Mutation_acceptRelationshipRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["followedID"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("followedID"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["followedID"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_createAuthUser_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -935,6 +1138,36 @@ func (ec *executionContext) field_Mutation_deleteItem_args(ctx context.Context, 
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteRelationship_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["followedID"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("followedID"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["followedID"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_ngRelationshipRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["followedID"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("followedID"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["followedID"] = arg0
 	return args, nil
 }
 
@@ -1073,7 +1306,37 @@ func (ec *executionContext) field_Query_relationshipRequests_args(ctx context.Co
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_relationships_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.InputRelationships
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNInputRelationships2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐInputRelationships(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_RelationshipRequest_user_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *bool
+	if tmp, ok := rawArgs["skip"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skip"))
+		arg0, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["skip"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Relationship_user_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 *bool
@@ -2082,6 +2345,132 @@ func (ec *executionContext) _Mutation_createRelationshipRequest(ctx context.Cont
 	return ec.marshalNRelationshipRequest2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequest(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_acceptRelationshipRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_acceptRelationshipRequest_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().AcceptRelationshipRequest(rctx, args["followedID"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.RelationshipRequest)
+	fc.Result = res
+	return ec.marshalNRelationshipRequest2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_ngRelationshipRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_ngRelationshipRequest_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().NgRelationshipRequest(rctx, args["followedID"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.RelationshipRequest)
+	fc.Result = res
+	return ec.marshalNRelationshipRequest2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_deleteRelationship(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_deleteRelationship_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteRelationship(rctx, args["followedID"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Relationship)
+	fc.Result = res
+	return ec.marshalNRelationship2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PageInfo_endCursor(ctx context.Context, field graphql.CollectedField, obj *model.PageInfo) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -2465,6 +2854,48 @@ func (ec *executionContext) _Query_relationshipRequests(ctx context.Context, fie
 	return ec.marshalNRelationshipRequests2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequests(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Query_relationships(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Query_relationships_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Relationships(rctx, args["input"].(model.InputRelationships))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Relationships)
+	fc.Result = res
+	return ec.marshalNRelationships2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationships(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -2534,6 +2965,287 @@ func (ec *executionContext) _Query___schema(ctx context.Context, field graphql.C
 	res := resTmp.(*introspection.Schema)
 	fc.Result = res
 	return ec.marshalO__Schema2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐSchema(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_id(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_followerId(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FollowerID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_followedId(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FollowedID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationship_user(ctx context.Context, field graphql.CollectedField, obj *model.Relationship) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationship",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Relationship_user_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.User, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalOUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _RelationshipEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.RelationshipEdge) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "RelationshipEdge",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Relationship)
+	fc.Result = res
+	return ec.marshalORelationship2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _RelationshipEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.RelationshipEdge) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "RelationshipEdge",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _RelationshipRequest_id(ctx context.Context, field graphql.CollectedField, obj *model.RelationshipRequest) (ret graphql.Marshaler) {
@@ -2920,6 +3632,76 @@ func (ec *executionContext) _RelationshipRequests_edges(ctx context.Context, fie
 	res := resTmp.([]*model.RelationshipRequestEdge)
 	fc.Result = res
 	return ec.marshalNRelationshipRequestEdge2ᚕᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequestEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationships_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.Relationships) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationships",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Relationships_edges(ctx context.Context, field graphql.CollectedField, obj *model.Relationships) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Relationships",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.RelationshipEdge)
+	fc.Result = res
+	return ec.marshalNRelationshipEdge2ᚕᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipEdgeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -4276,6 +5058,34 @@ func (ec *executionContext) unmarshalInputInputRelationshipRequests(ctx context.
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputInputRelationships(ctx context.Context, obj interface{}) (model.InputRelationships, error) {
+	var it model.InputRelationships
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "after":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+			it.After, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "first":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+			it.First, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNewItem(ctx context.Context, obj interface{}) (model.NewItem, error) {
 	var it model.NewItem
 	var asMap = obj.(map[string]interface{})
@@ -4694,6 +5504,21 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "acceptRelationshipRequest":
+			out.Values[i] = ec._Mutation_acceptRelationshipRequest(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "ngRelationshipRequest":
+			out.Values[i] = ec._Mutation_ngRelationshipRequest(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteRelationship":
+			out.Values[i] = ec._Mutation_deleteRelationship(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4855,10 +5680,102 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				}
 				return res
 			})
+		case "relationships":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_relationships(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "__type":
 			out.Values[i] = ec._Query___type(ctx, field)
 		case "__schema":
 			out.Values[i] = ec._Query___schema(ctx, field)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var relationshipImplementors = []string{"Relationship"}
+
+func (ec *executionContext) _Relationship(ctx context.Context, sel ast.SelectionSet, obj *model.Relationship) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, relationshipImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Relationship")
+		case "id":
+			out.Values[i] = ec._Relationship_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "followerId":
+			out.Values[i] = ec._Relationship_followerId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "followedId":
+			out.Values[i] = ec._Relationship_followedId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._Relationship_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Relationship_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "user":
+			out.Values[i] = ec._Relationship_user(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var relationshipEdgeImplementors = []string{"RelationshipEdge"}
+
+func (ec *executionContext) _RelationshipEdge(ctx context.Context, sel ast.SelectionSet, obj *model.RelationshipEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, relationshipEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RelationshipEdge")
+		case "node":
+			out.Values[i] = ec._RelationshipEdge_node(ctx, field, obj)
+		case "cursor":
+			out.Values[i] = ec._RelationshipEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4971,6 +5888,38 @@ func (ec *executionContext) _RelationshipRequests(ctx context.Context, sel ast.S
 			}
 		case "edges":
 			out.Values[i] = ec._RelationshipRequests_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var relationshipsImplementors = []string{"Relationships"}
+
+func (ec *executionContext) _Relationships(ctx context.Context, sel ast.SelectionSet, obj *model.Relationships) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, relationshipsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Relationships")
+		case "pageInfo":
+			out.Values[i] = ec._Relationships_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "edges":
+			out.Values[i] = ec._Relationships_edges(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -5322,6 +6271,11 @@ func (ec *executionContext) unmarshalNInputRelationshipRequests2githubᚗcomᚋw
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNInputRelationships2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐInputRelationships(ctx context.Context, v interface{}) (model.InputRelationships, error) {
+	res, err := ec.unmarshalInputInputRelationships(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}) (int, error) {
 	res, err := graphql.UnmarshalInt(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -5451,6 +6405,67 @@ func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋwheatandcatᚋmem
 	return ec._PageInfo(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNRelationship2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx context.Context, sel ast.SelectionSet, v model.Relationship) graphql.Marshaler {
+	return ec._Relationship(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRelationship2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx context.Context, sel ast.SelectionSet, v *model.Relationship) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Relationship(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRelationshipEdge2ᚕᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.RelationshipEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNRelationshipEdge2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNRelationshipEdge2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipEdge(ctx context.Context, sel ast.SelectionSet, v *model.RelationshipEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._RelationshipEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNRelationshipRequest2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequest(ctx context.Context, sel ast.SelectionSet, v model.RelationshipRequest) graphql.Marshaler {
 	return ec._RelationshipRequest(ctx, sel, &v)
 }
@@ -5524,6 +6539,20 @@ func (ec *executionContext) marshalNRelationshipRequests2ᚖgithubᚗcomᚋwheat
 		return graphql.Null
 	}
 	return ec._RelationshipRequests(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRelationships2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationships(ctx context.Context, sel ast.SelectionSet, v model.Relationships) graphql.Marshaler {
+	return ec._Relationships(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRelationships2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationships(ctx context.Context, sel ast.SelectionSet, v *model.Relationships) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Relationships(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {
@@ -5893,6 +6922,13 @@ func (ec *executionContext) marshalOItem2ᚖgithubᚗcomᚋwheatandcatᚋmemoir�
 		return graphql.Null
 	}
 	return ec._Item(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalORelationship2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx context.Context, sel ast.SelectionSet, v *model.Relationship) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Relationship(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalORelationshipRequest2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationshipRequest(ctx context.Context, sel ast.SelectionSet, v *model.RelationshipRequest) graphql.Marshaler {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -8,6 +8,7 @@ type Application struct {
 	ItemRepository                repository.ItemRepositoryInterface
 	InviteRepository              repository.InviteRepositoryInterface
 	RelationshipRequestRepository repository.RelationshipRequestInterface
+	RelationshipRepository        repository.RelationshipInterface
 }
 
 // NewApplication アプリケーションを作成する
@@ -17,5 +18,6 @@ func NewApplication() *Application {
 		ItemRepository:                repository.NewItemRepository(),
 		InviteRepository:              repository.NewInviteRepository(),
 		RelationshipRequestRepository: repository.NewRelationshipRequestRepository(),
+		RelationshipRepository:        repository.NewRelationshipRepository(),
 	}
 }

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -9,6 +9,7 @@ type Application struct {
 	InviteRepository              repository.InviteRepositoryInterface
 	RelationshipRequestRepository repository.RelationshipRequestInterface
 	RelationshipRepository        repository.RelationshipInterface
+	CommonRepository              repository.CommonRepositoryInterface
 }
 
 // NewApplication アプリケーションを作成する
@@ -19,5 +20,6 @@ func NewApplication() *Application {
 		InviteRepository:              repository.NewInviteRepository(),
 		RelationshipRequestRepository: repository.NewRelationshipRequestRepository(),
 		RelationshipRepository:        repository.NewRelationshipRepository(),
+		CommonRepository:              repository.NewCommonRepository(),
 	}
 }

--- a/graph/invite.go
+++ b/graph/invite.go
@@ -37,7 +37,7 @@ func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	batch := g.FirestoreClient.Batch()
 	g.App.InviteRepository.Create(ctx, g.FirestoreClient, batch, i)
 
-	if err := g.App.InviteRepository.Commit(ctx, batch); err != nil {
+	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
 		return nil, err
 	}
 
@@ -66,7 +66,7 @@ func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 	i.UpdatedAt = g.Client.Time.Now()
 	g.App.InviteRepository.Create(ctx, g.FirestoreClient, batch, i)
 
-	if err := g.App.InviteRepository.Commit(ctx, batch); err != nil {
+	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
 		return nil, err
 	}
 

--- a/graph/invite_test.go
+++ b/graph/invite_test.go
@@ -40,12 +40,15 @@ func TestCreateInvite(t *testing.T) {
 		FindByUserIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error) {
 			return &model.Invite{}, nil
 		},
+	}
+	commonRepositoryMock := &repository.CommonRepositoryInterfaceMock{
 		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
 			return nil
 		},
 	}
 
 	g.App.InviteRepository = inviteRepositoryMock
+	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string
@@ -102,12 +105,16 @@ func TestUpdateInvite(t *testing.T) {
 				CreatedAt: date,
 			}, nil
 		},
+	}
+
+	commonRepositoryMock := &repository.CommonRepositoryInterfaceMock{
 		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
 			return nil
 		},
 	}
 
 	g.App.InviteRepository = inviteRepositoryMock
+	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -23,6 +23,11 @@ type InputRelationshipRequests struct {
 	First int     `json:"first"`
 }
 
+type InputRelationships struct {
+	After *string `json:"after"`
+	First int     `json:"first"`
+}
+
 type Invite struct {
 	// ユーザーID
 	UserID string `json:"userID"`
@@ -89,6 +94,26 @@ type PageInfo struct {
 	HasNextPage bool   `json:"hasNextPage"`
 }
 
+type Relationship struct {
+	// ID
+	ID string `json:"id"`
+	// フォローしたユーザーID
+	FollowerID string `json:"followerId"`
+	// フォローされたユーザーID
+	FollowedID string `json:"followedId"`
+	// 作成日時
+	CreatedAt time.Time `json:"createdAt"`
+	// 更新日時
+	UpdatedAt time.Time `json:"updatedAt"`
+	// ユーザー情報
+	User *User `json:"user"`
+}
+
+type RelationshipEdge struct {
+	Node   *Relationship `json:"node"`
+	Cursor string        `json:"cursor"`
+}
+
 type RelationshipRequest struct {
 	// ID
 	ID string `json:"id"`
@@ -114,6 +139,11 @@ type RelationshipRequestEdge struct {
 type RelationshipRequests struct {
 	PageInfo *PageInfo                  `json:"pageInfo"`
 	Edges    []*RelationshipRequestEdge `json:"edges"`
+}
+
+type Relationships struct {
+	PageInfo *PageInfo           `json:"pageInfo"`
+	Edges    []*RelationshipEdge `json:"edges"`
 }
 
 type UpdateItem struct {

--- a/graph/relationship.go
+++ b/graph/relationship.go
@@ -1,0 +1,118 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/wheatandcat/memoir-backend/graph/model"
+	"github.com/wheatandcat/memoir-backend/repository"
+)
+
+// DeleteRelationship 共有ユーザーを解除する
+func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error) {
+	if !g.Client.AuthToken.Valid(ctx) {
+		return nil, fmt.Errorf("Invalid Authorization")
+	}
+
+	batch := g.FirestoreClient.Batch()
+
+	r1 := &model.Relationship{
+		FollowerID: g.UserID,
+		FollowedID: followedID,
+	}
+	r2 := &model.Relationship{
+		FollowerID: followedID,
+		FollowedID: g.UserID,
+	}
+
+	g.App.RelationshipRepository.Delete(ctx, g.FirestoreClient, batch, r1)
+	g.App.RelationshipRepository.Delete(ctx, g.FirestoreClient, batch, r2)
+
+	if _, err := batch.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return r1, nil
+}
+
+// GetRelationships 共有の招待リクエストを取得する
+func (g *Graph) GetRelationships(ctx context.Context, input model.InputRelationships, userSkip bool) (*model.Relationships, error) {
+	t := g.Client.Time
+	if !g.Client.AuthToken.Valid(ctx) {
+		return nil, fmt.Errorf("Invalid Authorization")
+	}
+
+	cursor := repository.RelationshipCursor{
+		FollowerID: "",
+		FollowedID: "",
+	}
+
+	cursorDate := strings.Split(*input.After, "/")
+	if len(cursorDate) > 1 {
+		cursor = repository.RelationshipCursor{
+			FollowerID: cursorDate[0],
+			FollowedID: cursorDate[1],
+		}
+	}
+
+	items, err := g.App.RelationshipRepository.FindByFollowedID(ctx, g.FirestoreClient, g.UserID, input.First, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	userID := []string{}
+	for _, i := range items {
+		userID = append(userID, i.FollowerID)
+	}
+	users := []*model.User{}
+
+	if !userSkip {
+		users, err = g.App.UserRepository.FindInUID(ctx, g.FirestoreClient, userID)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	var rres []*model.RelationshipEdge
+
+	for index, i := range items {
+		items[index].CreatedAt = t.Location(i.CreatedAt)
+		items[index].UpdatedAt = t.Location(i.UpdatedAt)
+
+		user := &model.User{}
+
+		for _, u := range users {
+
+			if u.ID == i.FollowerID {
+				user = u
+			}
+
+		}
+
+		items[index].User = user
+
+		rres = append(rres, &model.RelationshipEdge{
+			Node:   items[index],
+			Cursor: i.FollowedID + "/" + i.FollowerID,
+		})
+
+	}
+
+	pi := &model.PageInfo{
+		HasNextPage: false,
+		EndCursor:   "",
+	}
+
+	if len(rres) > 0 {
+		pi.HasNextPage = input.First == len(items)
+		pi.EndCursor = rres[len(items)-1].Cursor
+	}
+	ibp := &model.Relationships{
+		Edges:    rres,
+		PageInfo: pi,
+	}
+
+	return ibp, nil
+}

--- a/graph/relationship.go
+++ b/graph/relationship.go
@@ -29,7 +29,7 @@ func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*mod
 	g.App.RelationshipRepository.Delete(ctx, g.FirestoreClient, batch, r1)
 	g.App.RelationshipRepository.Delete(ctx, g.FirestoreClient, batch, r2)
 
-	if _, err := batch.Commit(ctx); err != nil {
+	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
 		return nil, err
 	}
 

--- a/graph/relationship_request.go
+++ b/graph/relationship_request.go
@@ -79,12 +79,14 @@ func (g *Graph) AcceptRelationshipRequest(ctx context.Context, followedID string
 	g.App.RelationshipRequestRepository.Update(ctx, g.FirestoreClient, batch, rr)
 
 	r1 := &model.Relationship{
+		ID:         g.Client.UUID.Get(),
 		FollowerID: g.UserID,
 		FollowedID: followedID,
 		CreatedAt:  g.Client.Time.Now(),
 		UpdatedAt:  g.Client.Time.Now(),
 	}
 	r2 := &model.Relationship{
+		ID:         g.Client.UUID.Get(),
 		FollowerID: followedID,
 		FollowedID: g.UserID,
 		CreatedAt:  g.Client.Time.Now(),
@@ -93,7 +95,7 @@ func (g *Graph) AcceptRelationshipRequest(ctx context.Context, followedID string
 	g.App.RelationshipRepository.Create(ctx, g.FirestoreClient, batch, r1)
 	g.App.RelationshipRepository.Create(ctx, g.FirestoreClient, batch, r2)
 
-	if _, err := batch.Commit(ctx); err != nil {
+	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +103,7 @@ func (g *Graph) AcceptRelationshipRequest(ctx context.Context, followedID string
 }
 
 // ngRelationshipRequest 招待リクエストを拒否する
-func (g *Graph) ngRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
+func (g *Graph) NgRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
 		return nil, fmt.Errorf("Invalid Authorization")
 	}
@@ -115,7 +117,7 @@ func (g *Graph) ngRelationshipRequest(ctx context.Context, followedID string) (*
 	batch := g.FirestoreClient.Batch()
 	g.App.RelationshipRequestRepository.Update(ctx, g.FirestoreClient, batch, rr)
 
-	if _, err := batch.Commit(ctx); err != nil {
+	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
 		return nil, err
 	}
 

--- a/graph/relationship_request_test.go
+++ b/graph/relationship_request_test.go
@@ -27,7 +27,7 @@ func TestCreateRelationshipRequest(t *testing.T) {
 	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
 
 	u := &model.User{
-		ID:          "test",
+		ID:          "test2",
 		DisplayName: "test",
 		CreatedAt:   date,
 		UpdatedAt:   date,
@@ -36,7 +36,7 @@ func TestCreateRelationshipRequest(t *testing.T) {
 	rr := &model.RelationshipRequest{
 		ID:         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 		FollowerID: "test",
-		FollowedID: "test",
+		FollowedID: "test2",
 		Status:     repository.RelationshipRequestStatusRequest,
 		CreatedAt:  date,
 		UpdatedAt:  date,
@@ -44,7 +44,7 @@ func TestCreateRelationshipRequest(t *testing.T) {
 	}
 
 	invite := &model.Invite{
-		UserID:    "test",
+		UserID:    "test2",
 		Code:      "ABCDEFGH",
 		CreatedAt: date,
 		UpdatedAt: date,
@@ -94,6 +94,125 @@ func TestCreateRelationshipRequest(t *testing.T) {
 	for _, td := range tests {
 		t.Run(td.name, func(t *testing.T) {
 			r, _ := g.CreateRelationshipRequest(ctx, td.param)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+		})
+	}
+}
+
+func TestAcceptRelationshipRequest(t *testing.T) {
+	ctx := context.Background()
+
+	client := &graph.Client{
+		UUID: &uuidgen.UUID{},
+		Time: &timegen.Time{},
+	}
+
+	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
+
+	rr := &model.RelationshipRequest{
+		FollowerID: "test",
+		FollowedID: "test",
+		Status:     repository.RelationshipRequestStatusOK,
+		UpdatedAt:  date,
+	}
+
+	g := newGraph()
+
+	relationshipRequestRepositoryMock := &repository.RelationshipRequestInterfaceMock{
+		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.RelationshipRequest) {
+		},
+	}
+	relationshipRepositoryMock := &repository.RelationshipInterfaceMock{
+		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+		},
+	}
+	commonRepositoryMock := &repository.CommonRepositoryInterfaceMock{
+		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
+			return nil
+		},
+	}
+
+	g.App.RelationshipRequestRepository = relationshipRequestRepositoryMock
+	g.App.RelationshipRepository = relationshipRepositoryMock
+	g.App.CommonRepository = commonRepositoryMock
+
+	tests := []struct {
+		name   string
+		param  string
+		result *model.RelationshipRequest
+	}{
+		{
+			name:   "招待リクエストを承諾する",
+			param:  "test",
+			result: rr,
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			r, _ := g.AcceptRelationshipRequest(ctx, td.param)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+		})
+	}
+}
+
+func TestNgRelationshipRequest(t *testing.T) {
+	ctx := context.Background()
+
+	client := &graph.Client{
+		UUID: &uuidgen.UUID{},
+		Time: &timegen.Time{},
+	}
+
+	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
+
+	rr := &model.RelationshipRequest{
+		FollowerID: "test",
+		FollowedID: "test",
+		Status:     repository.RelationshipRequestStatusNG,
+		UpdatedAt:  date,
+	}
+
+	g := newGraph()
+
+	relationshipRequestRepositoryMock := &repository.RelationshipRequestInterfaceMock{
+		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.RelationshipRequest) {
+		},
+	}
+	commonRepositoryMock := &repository.CommonRepositoryInterfaceMock{
+		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
+			return nil
+		},
+	}
+
+	g.App.RelationshipRequestRepository = relationshipRequestRepositoryMock
+	g.App.CommonRepository = commonRepositoryMock
+
+	tests := []struct {
+		name   string
+		param  string
+		result *model.RelationshipRequest
+	}{
+		{
+			name:   "招待リクエストを拒否する",
+			param:  "test",
+			result: rr,
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			r, _ := g.NgRelationshipRequest(ctx, td.param)
 			diff := cmp.Diff(r, td.result)
 			if diff != "" {
 				t.Errorf("differs: (-got +want)\n%s", diff)

--- a/graph/relationship_test.go
+++ b/graph/relationship_test.go
@@ -1,0 +1,168 @@
+package graph_test
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/go-cmp/cmp"
+	"github.com/wheatandcat/memoir-backend/client/timegen"
+	"github.com/wheatandcat/memoir-backend/client/uuidgen"
+	"github.com/wheatandcat/memoir-backend/graph"
+	"github.com/wheatandcat/memoir-backend/graph/model"
+	"github.com/wheatandcat/memoir-backend/repository"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+func TestDeleteRelationship(t *testing.T) {
+	ctx := context.Background()
+
+	rr := &model.Relationship{
+		FollowerID: "test",
+		FollowedID: "test",
+	}
+
+	g := newGraph()
+
+	relationshipRepositoryMock := &repository.RelationshipInterfaceMock{
+		DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+		},
+	}
+	commonRepositoryMock := &repository.CommonRepositoryInterfaceMock{
+		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
+			return nil
+		},
+	}
+
+	g.App.RelationshipRepository = relationshipRepositoryMock
+	g.App.CommonRepository = commonRepositoryMock
+
+	tests := []struct {
+		name   string
+		param  string
+		result *model.Relationship
+	}{
+		{
+			name:   "共有ユーザーを解除する",
+			param:  "test",
+			result: rr,
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			r, _ := g.DeleteRelationship(ctx, td.param)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+		})
+	}
+
+}
+
+func TestGetRelationships(t *testing.T) {
+	ctx := context.Background()
+
+	client := &graph.Client{
+		UUID: &uuidgen.UUID{},
+		Time: &timegen.Time{},
+	}
+
+	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
+
+	user := &model.User{
+		ID:          "test",
+		DisplayName: "",
+		Image:       "",
+		CreatedAt:   date,
+		UpdatedAt:   date,
+	}
+
+	rr := []*model.Relationship{{
+		ID:         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		FollowerID: "test",
+		FollowedID: "test",
+		CreatedAt:  date,
+		UpdatedAt:  date,
+		User:       user,
+	}}
+
+	rres := []*model.RelationshipEdge{{
+		Node: &model.Relationship{
+			ID:         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			FollowerID: "test",
+			FollowedID: "test",
+			CreatedAt:  date,
+			UpdatedAt:  date,
+			User:       user,
+		},
+		Cursor: "test/test",
+	}}
+
+	rrs := &model.Relationships{
+		PageInfo: &model.PageInfo{
+			EndCursor:   "test/test",
+			HasNextPage: false,
+		},
+		Edges: rres,
+	}
+
+	users := []*model.User{{
+		ID:          "test",
+		DisplayName: "",
+		Image:       "",
+		CreatedAt:   date,
+		UpdatedAt:   date,
+	}}
+
+	g := newGraph()
+
+	relationshipRepositoryMock := &repository.RelationshipInterfaceMock{
+		FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipCursor) ([]*model.Relationship, error) {
+			return rr, nil
+		},
+	}
+
+	userRepositoryInterfaceMock := &repository.UserRepositoryInterfaceMock{
+		FindInUIDFunc: func(ctx context.Context, f *firestore.Client, uid []string) ([]*model.User, error) {
+			return users, nil
+		},
+	}
+
+	g.App.UserRepository = userRepositoryInterfaceMock
+	g.App.RelationshipRepository = relationshipRepositoryMock
+
+	after := ""
+
+	tests := []struct {
+		name     string
+		param    model.InputRelationships
+		userSkip bool
+		result   *model.Relationships
+	}{
+		{
+			name: "共有メンバーを取得する",
+			param: model.InputRelationships{
+				First: 5,
+				After: &after,
+			},
+			userSkip: false,
+			result:   rrs,
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			r, _ := g.GetRelationships(ctx, td.param, td.userSkip)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+		})
+	}
+}

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -99,6 +99,36 @@ input InputRelationshipRequests {
   first: Int!
 }
 
+type Relationship {
+  "ID"
+  id: ID!
+  "フォローしたユーザーID"
+  followerId: String!
+  "フォローされたユーザーID"
+  followedId: String!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+  "ユーザー情報"
+  user(skip: Boolean): User
+}
+
+type RelationshipEdge {
+  node: Relationship
+  cursor: String!
+}
+
+type Relationships {
+  pageInfo: PageInfo!
+  edges: [RelationshipEdge!]!
+}
+
+input InputRelationships {
+  after: String
+  first: Int!
+}
+
 type Query {
   "ユーザーを取得する"
   user: User!
@@ -116,6 +146,8 @@ type Query {
   inviteByCode(code: String!): User!
   "招待の申請リクエストを取得する"
   relationshipRequests(input: InputRelationshipRequests!): RelationshipRequests!
+  "共有ユーザーを取得する"
+  relationships(input: InputRelationships!): Relationships!
 }
 
 input NewUser {
@@ -185,6 +217,12 @@ type Mutation {
   createRelationshipRequest(
     input: NewRelationshipRequest!
   ): RelationshipRequest!
+  "招待リクエストを承諾する"
+  acceptRelationshipRequest(followedID: String!): RelationshipRequest!
+  "招待リクエストを拒否する"
+  ngRelationshipRequest(followedID: String!): RelationshipRequest!
+  "共有メンバーを解除する"
+  deleteRelationship(followedID: String!): Relationship!
 }
 
 scalar Time

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -5,6 +5,7 @@ package graph
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -124,6 +125,48 @@ func (r *mutationResolver) CreateRelationshipRequest(ctx context.Context, input 
 	}
 
 	result, err := g.CreateRelationshipRequest(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *mutationResolver) AcceptRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.AcceptRelationshipRequest(ctx, followedID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *mutationResolver) NgRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.ngRelationshipRequest(ctx, followedID)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (r *mutationResolver) DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.DeleteRelationship(ctx, followedID)
 	if err != nil {
 		return nil, err
 	}
@@ -254,6 +297,31 @@ func (r *queryResolver) RelationshipRequests(ctx context.Context, input model.In
 	return result, nil
 }
 
+func (r *queryResolver) Relationships(ctx context.Context, input model.InputRelationships) (*model.Relationships, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	userSkip := true
+	fields := graphql.CollectFieldsCtx(ctx, nil)
+
+	edges := GetNestCollectFields(ctx, fields, "edges")
+	nodes := GetNestCollectFields(ctx, edges, "node")
+	value := GetNestCollectFieldArgumentValue(ctx, nodes, "user", "skip")
+
+	if value == "false" {
+		userSkip = false
+	}
+
+	result, err := g.GetRelationships(ctx, input, userSkip)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // Mutation returns generated.MutationResolver implementation.
 func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
 
@@ -262,3 +330,16 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *mutationResolver) AcceptRelationship(ctx context.Context, id string) (*model.Relationship, error) {
+	panic(fmt.Errorf("not implemented"))
+}
+func (r *mutationResolver) NgRelationship(ctx context.Context, id string) (*model.Relationship, error) {
+	panic(fmt.Errorf("not implemented"))
+}

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -152,7 +152,7 @@ func (r *mutationResolver) NgRelationshipRequest(ctx context.Context, followedID
 		return nil, err
 	}
 
-	result, err := g.ngRelationshipRequest(ctx, followedID)
+	result, err := g.NgRelationshipRequest(ctx, followedID)
 	if err != nil {
 		return nil, err
 	}

--- a/repository/common.go
+++ b/repository/common.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+)
+
+type CommonRepositoryInterface interface {
+	Commit(ctx context.Context, batch *firestore.WriteBatch) error
+}
+
+type CommonRepository struct {
+}
+
+func NewCommonRepository() CommonRepositoryInterface {
+	return &CommonRepository{}
+}
+
+// Commit コミットする
+func (re *CommonRepository) Commit(ctx context.Context, batch *firestore.WriteBatch) error {
+	_, err := batch.Commit(ctx)
+
+	return err
+}

--- a/repository/invite.go
+++ b/repository/invite.go
@@ -12,7 +12,6 @@ import (
 type InviteRepositoryInterface interface {
 	Create(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Invite)
 	Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, code string)
-	Commit(ctx context.Context, batch *firestore.WriteBatch) error
 	Find(ctx context.Context, f *firestore.Client, code string) (*model.Invite, error)
 	FindByUserID(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error)
 }
@@ -34,13 +33,6 @@ func (re *InviteRepository) Create(ctx context.Context, f *firestore.Client, bat
 func (re *InviteRepository) Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, code string) {
 	ref := f.Collection("invites").Doc(code)
 	batch.Delete(ref)
-}
-
-// Commit コミットする
-func (re *InviteRepository) Commit(ctx context.Context, batch *firestore.WriteBatch) error {
-	_, err := batch.Commit(ctx)
-
-	return err
 }
 
 // FindByUserID ユーザーIDから取得する

--- a/repository/moq.go
+++ b/repository/moq.go
@@ -974,9 +974,6 @@ var _ InviteRepositoryInterface = &InviteRepositoryInterfaceMock{}
 //
 // 		// make and configure a mocked InviteRepositoryInterface
 // 		mockedInviteRepositoryInterface := &InviteRepositoryInterfaceMock{
-// 			CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
-// 				panic("mock out the Commit method")
-// 			},
 // 			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Invite)  {
 // 				panic("mock out the Create method")
 // 			},
@@ -996,9 +993,6 @@ var _ InviteRepositoryInterface = &InviteRepositoryInterfaceMock{}
 //
 // 	}
 type InviteRepositoryInterfaceMock struct {
-	// CommitFunc mocks the Commit method.
-	CommitFunc func(ctx context.Context, batch *firestore.WriteBatch) error
-
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Invite)
 
@@ -1013,13 +1007,6 @@ type InviteRepositoryInterfaceMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// Commit holds details about calls to the Commit method.
-		Commit []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Batch is the batch argument value.
-			Batch *firestore.WriteBatch
-		}
 		// Create holds details about calls to the Create method.
 		Create []struct {
 			// Ctx is the ctx argument value.
@@ -1061,46 +1048,10 @@ type InviteRepositoryInterfaceMock struct {
 			UserID string
 		}
 	}
-	lockCommit       sync.RWMutex
 	lockCreate       sync.RWMutex
 	lockDelete       sync.RWMutex
 	lockFind         sync.RWMutex
 	lockFindByUserID sync.RWMutex
-}
-
-// Commit calls CommitFunc.
-func (mock *InviteRepositoryInterfaceMock) Commit(ctx context.Context, batch *firestore.WriteBatch) error {
-	if mock.CommitFunc == nil {
-		panic("InviteRepositoryInterfaceMock.CommitFunc: method is nil but InviteRepositoryInterface.Commit was just called")
-	}
-	callInfo := struct {
-		Ctx   context.Context
-		Batch *firestore.WriteBatch
-	}{
-		Ctx:   ctx,
-		Batch: batch,
-	}
-	mock.lockCommit.Lock()
-	mock.calls.Commit = append(mock.calls.Commit, callInfo)
-	mock.lockCommit.Unlock()
-	return mock.CommitFunc(ctx, batch)
-}
-
-// CommitCalls gets all the calls that were made to Commit.
-// Check the length with:
-//     len(mockedInviteRepositoryInterface.CommitCalls())
-func (mock *InviteRepositoryInterfaceMock) CommitCalls() []struct {
-	Ctx   context.Context
-	Batch *firestore.WriteBatch
-} {
-	var calls []struct {
-		Ctx   context.Context
-		Batch *firestore.WriteBatch
-	}
-	mock.lockCommit.RLock()
-	calls = mock.calls.Commit
-	mock.lockCommit.RUnlock()
-	return calls
 }
 
 // Create calls CreateFunc.
@@ -1524,5 +1475,287 @@ func (mock *RelationshipRequestInterfaceMock) UpdateCalls() []struct {
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update
 	mock.lockUpdate.RUnlock()
+	return calls
+}
+
+// Ensure, that RelationshipInterfaceMock does implement RelationshipInterface.
+// If this is not the case, regenerate this file with moq.
+var _ RelationshipInterface = &RelationshipInterfaceMock{}
+
+// RelationshipInterfaceMock is a mock implementation of RelationshipInterface.
+//
+// 	func TestSomethingThatUsesRelationshipInterface(t *testing.T) {
+//
+// 		// make and configure a mocked RelationshipInterface
+// 		mockedRelationshipInterface := &RelationshipInterfaceMock{
+// 			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)  {
+// 				panic("mock out the Create method")
+// 			},
+// 			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)  {
+// 				panic("mock out the Delete method")
+// 			},
+// 			FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipCursor) ([]*model.Relationship, error) {
+// 				panic("mock out the FindByFollowedID method")
+// 			},
+// 		}
+//
+// 		// use mockedRelationshipInterface in code that requires RelationshipInterface
+// 		// and then make assertions.
+//
+// 	}
+type RelationshipInterfaceMock struct {
+	// CreateFunc mocks the Create method.
+	CreateFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)
+
+	// DeleteFunc mocks the Delete method.
+	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)
+
+	// FindByFollowedIDFunc mocks the FindByFollowedID method.
+	FindByFollowedIDFunc func(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipCursor) ([]*model.Relationship, error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Create holds details about calls to the Create method.
+		Create []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// I is the i argument value.
+			I *model.Relationship
+		}
+		// Delete holds details about calls to the Delete method.
+		Delete []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// I is the i argument value.
+			I *model.Relationship
+		}
+		// FindByFollowedID holds details about calls to the FindByFollowedID method.
+		FindByFollowedID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// UserID is the userID argument value.
+			UserID string
+			// First is the first argument value.
+			First int
+			// Cursor is the cursor argument value.
+			Cursor RelationshipCursor
+		}
+	}
+	lockCreate           sync.RWMutex
+	lockDelete           sync.RWMutex
+	lockFindByFollowedID sync.RWMutex
+}
+
+// Create calls CreateFunc.
+func (mock *RelationshipInterfaceMock) Create(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+	if mock.CreateFunc == nil {
+		panic("RelationshipInterfaceMock.CreateFunc: method is nil but RelationshipInterface.Create was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		I     *model.Relationship
+	}{
+		Ctx:   ctx,
+		F:     f,
+		Batch: batch,
+		I:     i,
+	}
+	mock.lockCreate.Lock()
+	mock.calls.Create = append(mock.calls.Create, callInfo)
+	mock.lockCreate.Unlock()
+	mock.CreateFunc(ctx, f, batch, i)
+}
+
+// CreateCalls gets all the calls that were made to Create.
+// Check the length with:
+//     len(mockedRelationshipInterface.CreateCalls())
+func (mock *RelationshipInterfaceMock) CreateCalls() []struct {
+	Ctx   context.Context
+	F     *firestore.Client
+	Batch *firestore.WriteBatch
+	I     *model.Relationship
+} {
+	var calls []struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		I     *model.Relationship
+	}
+	mock.lockCreate.RLock()
+	calls = mock.calls.Create
+	mock.lockCreate.RUnlock()
+	return calls
+}
+
+// Delete calls DeleteFunc.
+func (mock *RelationshipInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+	if mock.DeleteFunc == nil {
+		panic("RelationshipInterfaceMock.DeleteFunc: method is nil but RelationshipInterface.Delete was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		I     *model.Relationship
+	}{
+		Ctx:   ctx,
+		F:     f,
+		Batch: batch,
+		I:     i,
+	}
+	mock.lockDelete.Lock()
+	mock.calls.Delete = append(mock.calls.Delete, callInfo)
+	mock.lockDelete.Unlock()
+	mock.DeleteFunc(ctx, f, batch, i)
+}
+
+// DeleteCalls gets all the calls that were made to Delete.
+// Check the length with:
+//     len(mockedRelationshipInterface.DeleteCalls())
+func (mock *RelationshipInterfaceMock) DeleteCalls() []struct {
+	Ctx   context.Context
+	F     *firestore.Client
+	Batch *firestore.WriteBatch
+	I     *model.Relationship
+} {
+	var calls []struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		I     *model.Relationship
+	}
+	mock.lockDelete.RLock()
+	calls = mock.calls.Delete
+	mock.lockDelete.RUnlock()
+	return calls
+}
+
+// FindByFollowedID calls FindByFollowedIDFunc.
+func (mock *RelationshipInterfaceMock) FindByFollowedID(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipCursor) ([]*model.Relationship, error) {
+	if mock.FindByFollowedIDFunc == nil {
+		panic("RelationshipInterfaceMock.FindByFollowedIDFunc: method is nil but RelationshipInterface.FindByFollowedID was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+		First  int
+		Cursor RelationshipCursor
+	}{
+		Ctx:    ctx,
+		F:      f,
+		UserID: userID,
+		First:  first,
+		Cursor: cursor,
+	}
+	mock.lockFindByFollowedID.Lock()
+	mock.calls.FindByFollowedID = append(mock.calls.FindByFollowedID, callInfo)
+	mock.lockFindByFollowedID.Unlock()
+	return mock.FindByFollowedIDFunc(ctx, f, userID, first, cursor)
+}
+
+// FindByFollowedIDCalls gets all the calls that were made to FindByFollowedID.
+// Check the length with:
+//     len(mockedRelationshipInterface.FindByFollowedIDCalls())
+func (mock *RelationshipInterfaceMock) FindByFollowedIDCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	UserID string
+	First  int
+	Cursor RelationshipCursor
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+		First  int
+		Cursor RelationshipCursor
+	}
+	mock.lockFindByFollowedID.RLock()
+	calls = mock.calls.FindByFollowedID
+	mock.lockFindByFollowedID.RUnlock()
+	return calls
+}
+
+// Ensure, that CommonRepositoryInterfaceMock does implement CommonRepositoryInterface.
+// If this is not the case, regenerate this file with moq.
+var _ CommonRepositoryInterface = &CommonRepositoryInterfaceMock{}
+
+// CommonRepositoryInterfaceMock is a mock implementation of CommonRepositoryInterface.
+//
+// 	func TestSomethingThatUsesCommonRepositoryInterface(t *testing.T) {
+//
+// 		// make and configure a mocked CommonRepositoryInterface
+// 		mockedCommonRepositoryInterface := &CommonRepositoryInterfaceMock{
+// 			CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
+// 				panic("mock out the Commit method")
+// 			},
+// 		}
+//
+// 		// use mockedCommonRepositoryInterface in code that requires CommonRepositoryInterface
+// 		// and then make assertions.
+//
+// 	}
+type CommonRepositoryInterfaceMock struct {
+	// CommitFunc mocks the Commit method.
+	CommitFunc func(ctx context.Context, batch *firestore.WriteBatch) error
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Commit holds details about calls to the Commit method.
+		Commit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+		}
+	}
+	lockCommit sync.RWMutex
+}
+
+// Commit calls CommitFunc.
+func (mock *CommonRepositoryInterfaceMock) Commit(ctx context.Context, batch *firestore.WriteBatch) error {
+	if mock.CommitFunc == nil {
+		panic("CommonRepositoryInterfaceMock.CommitFunc: method is nil but CommonRepositoryInterface.Commit was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Batch *firestore.WriteBatch
+	}{
+		Ctx:   ctx,
+		Batch: batch,
+	}
+	mock.lockCommit.Lock()
+	mock.calls.Commit = append(mock.calls.Commit, callInfo)
+	mock.lockCommit.Unlock()
+	return mock.CommitFunc(ctx, batch)
+}
+
+// CommitCalls gets all the calls that were made to Commit.
+// Check the length with:
+//     len(mockedCommonRepositoryInterface.CommitCalls())
+func (mock *CommonRepositoryInterfaceMock) CommitCalls() []struct {
+	Ctx   context.Context
+	Batch *firestore.WriteBatch
+} {
+	var calls []struct {
+		Ctx   context.Context
+		Batch *firestore.WriteBatch
+	}
+	mock.lockCommit.RLock()
+	calls = mock.calls.Commit
+	mock.lockCommit.RUnlock()
 	return calls
 }

--- a/repository/relationship.go
+++ b/repository/relationship.go
@@ -1,0 +1,99 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/wheatandcat/memoir-backend/graph/model"
+)
+
+type RelationshipInterface interface {
+	Create(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)
+	Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)
+	FindByFollowedID(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipCursor) ([]*model.Relationship, error)
+}
+
+type RelationshipRepository struct {
+}
+
+func NewRelationshipRepository() RelationshipInterface {
+	return &RelationshipRepository{}
+}
+
+type RelationshipCursor struct {
+	FollowerID string
+	FollowedID string
+}
+
+type RelationshipData struct {
+	ID         string
+	FollowerID string
+	FollowedID string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// Create 作成する
+func (re *RelationshipRepository) Create(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+	rrd := RelationshipData{
+		ID:         i.ID,
+		FollowerID: i.FollowerID,
+		FollowedID: i.FollowedID,
+		CreatedAt:  i.CreatedAt,
+		UpdatedAt:  i.UpdatedAt,
+	}
+
+	ref := f.Collection("relationships").Doc(i.FollowerID + "_" + i.FollowedID)
+	batch.Set(ref, rrd)
+}
+
+// Delete 削除する
+func (re *RelationshipRepository) Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship) {
+	ref := f.Collection("relationships").Doc(i.FollowerID + "_" + i.FollowedID)
+	batch.Delete(ref)
+}
+
+// Find 取得する
+func (re *RelationshipRepository) Find(ctx context.Context, f *firestore.Client, i *model.Relationship) (*model.Relationship, error) {
+	var rr *model.Relationship
+	ds, err := f.Collection("relationships").Doc(i.FollowerID + "_" + i.FollowedID).Get(ctx)
+	if err != nil {
+		return i, err
+	}
+
+	ds.DataTo(&rr)
+
+	return rr, err
+}
+
+// FindByFollowedID ページングで取得する
+func (re *RelationshipRepository) FindByFollowedID(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipCursor) ([]*model.Relationship, error) {
+	var items []*model.Relationship
+	query := f.Collection("relationships").Where("FollowedID", "==", userID).OrderBy("CreatedAt", firestore.Desc)
+
+	if cursor.FollowerID != "" {
+		ds, err := f.Collection("relationships").Doc(cursor.FollowerID + "_" + cursor.FollowedID).Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		query = query.StartAfter(ds)
+	}
+
+	matchItem := query.Limit(first).Documents(ctx)
+	docs, err := matchItem.GetAll()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, doc := range docs {
+		var item *model.Relationship
+		doc.DataTo(&item)
+
+		items = append(items, item)
+	}
+
+	return items, nil
+}

--- a/repository/relationship_request.go
+++ b/repository/relationship_request.go
@@ -6,6 +6,8 @@ import (
 
 	"cloud.google.com/go/firestore"
 	"github.com/wheatandcat/memoir-backend/graph/model"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -57,7 +59,7 @@ func (re *RelationshipRequestRepository) Create(ctx context.Context, f *firestor
 	return err
 }
 
-// Create 更新する
+// Update 更新する
 func (re *RelationshipRequestRepository) Update(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.RelationshipRequest) {
 	var u []firestore.Update
 	if i.Status != 0 {
@@ -67,7 +69,6 @@ func (re *RelationshipRequestRepository) Update(ctx context.Context, f *firestor
 
 	ref := f.Collection("invites").Doc(i.FollowerID + "_" + i.FollowedID)
 	batch.Update(ref, u)
-
 }
 
 // Find 取得する
@@ -75,6 +76,10 @@ func (re *RelationshipRequestRepository) Find(ctx context.Context, f *firestore.
 	var rr *model.RelationshipRequest
 	ds, err := f.Collection("relationshipRequests").Doc(i.FollowerID + "_" + i.FollowedID).Get(ctx)
 	if err != nil {
+		if status.Code(err) == codes.InvalidArgument || status.Code(err) == codes.NotFound {
+			return &model.RelationshipRequest{}, nil
+		}
+
 		return i, err
 	}
 

--- a/schema.md
+++ b/schema.md
@@ -1,4 +1,4 @@
-yarn run v1.22.4
+yarn run v1.22.10
 $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.bin/graphql-markdown http://localhost:8080/query
 # Schema Types
 
@@ -13,14 +13,18 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
     * [ItemsInPeriod](#itemsinperiod)
     * [ItemsInPeriodEdge](#itemsinperiodedge)
     * [PageInfo](#pageinfo)
+    * [Relationship](#relationship)
+    * [RelationshipEdge](#relationshipedge)
     * [RelationshipRequest](#relationshiprequest)
     * [RelationshipRequestEdge](#relationshiprequestedge)
     * [RelationshipRequests](#relationshiprequests)
+    * [Relationships](#relationships)
     * [User](#user)
   * [Inputs](#inputs)
     * [DeleteItem](#deleteitem)
     * [InputItemsInPeriod](#inputitemsinperiod)
     * [InputRelationshipRequests](#inputrelationshiprequests)
+    * [InputRelationships](#inputrelationships)
     * [NewItem](#newitem)
     * [NewRelationshipRequest](#newrelationshiprequest)
     * [NewUser](#newuser)
@@ -149,6 +153,20 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td valign="top"><a href="#inputrelationshiprequests">InputRelationshipRequests</a>!</td>
 <td></td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>relationships</strong></td>
+<td valign="top"><a href="#relationships">Relationships</a>!</td>
+<td>
+
+共有ユーザーを取得する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#inputrelationships">InputRelationships</a>!</td>
+<td></td>
+</tr>
 </tbody>
 </table>
 
@@ -266,7 +284,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>newRelationshipRequest</strong></td>
+<td colspan="2" valign="top"><strong>createRelationshipRequest</strong></td>
 <td valign="top"><a href="#relationshiprequest">RelationshipRequest</a>!</td>
 <td>
 
@@ -277,6 +295,48 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <tr>
 <td colspan="2" align="right" valign="top">input</td>
 <td valign="top"><a href="#newrelationshiprequest">NewRelationshipRequest</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>acceptRelationshipRequest</strong></td>
+<td valign="top"><a href="#relationshiprequest">RelationshipRequest</a>!</td>
+<td>
+
+招待リクエストを承諾する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">followedID</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>ngRelationshipRequest</strong></td>
+<td valign="top"><a href="#relationshiprequest">RelationshipRequest</a>!</td>
+<td>
+
+招待リクエストを拒否する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">followedID</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deleteRelationship</strong></td>
+<td valign="top"><a href="#relationship">Relationship</a>!</td>
+<td>
+
+共有メンバーを解除する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">followedID</td>
+<td valign="top"><a href="#string">String</a>!</td>
 <td></td>
 </tr>
 </tbody>
@@ -498,6 +558,105 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 </tbody>
 </table>
 
+### Relationship
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>followerId</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+フォローしたユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>followedId</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+フォローされたユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createdAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+作成日時
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+更新日時
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td>
+
+ユーザー情報
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">skip</td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### RelationshipEdge
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#relationship">Relationship</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>cursor</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
 ### RelationshipRequest
 
 <table>
@@ -631,6 +790,31 @@ ID
 </tbody>
 </table>
 
+### Relationships
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>pageInfo</strong></td>
+<td valign="top"><a href="#pageinfo">PageInfo</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>edges</strong></td>
+<td valign="top">[<a href="#relationshipedge">RelationshipEdge</a>!]!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
 ### User
 
 <table>
@@ -751,6 +935,30 @@ ID
 </table>
 
 ### InputRelationshipRequests
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>after</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>first</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### InputRelationships
 
 <table>
 <thead>
@@ -986,5 +1194,3 @@ The `Int` scalar type represents non-fractional signed whole numeric values. Int
 The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
 
 ### Time
-
-Done in 2.56s.


### PR DESCRIPTION
## 関連 issue

- fixes #39

## 対応内容

以下のGraphQLを作成
 - Query
   - **relationships** : 共有ユーザーを取得する
 - Mutation
   - **acceptRelationshipRequest** : 招待リクエストを承諾する 
   - **ngRelationshipRequest** : 招待リクエストを拒否する 
   - **deleteRelationship** : 共有メンバーを解除する

## 開発用メモ
無し

