### PR TITLE
GetItemsInPeriodに共有ユーザーの情報を追加する

### DIFF
--- a/graph/item_test.go
+++ b/graph/item_test.go
@@ -89,6 +89,14 @@ func TestGetItemsInPeriod(t *testing.T) {
 		UpdatedAt:  date,
 	}}
 
+	rr := []*model.Relationship{{
+		ID:         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		FollowerID: "test",
+		FollowedID: "test",
+		CreatedAt:  date,
+		UpdatedAt:  date,
+	}}
+
 	g := newGraph()
 
 	itemRepositoryMock := &repository.ItemRepositoryInterfaceMock{
@@ -97,7 +105,14 @@ func TestGetItemsInPeriod(t *testing.T) {
 		},
 	}
 
+	relationshipRepositoryMock := &repository.RelationshipInterfaceMock{
+		FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipCursor) ([]*model.Relationship, error) {
+			return rr, nil
+		},
+	}
+
 	g.App.ItemRepository = itemRepositoryMock
+	g.App.RelationshipRepository = relationshipRepositoryMock
 	after := ""
 
 	iipe := []*model.ItemsInPeriodEdge{{


### PR DESCRIPTION
## 関連 issue

- fixes #28 

## 対応内容

 - QueryのitemsInPeriodに共有ユーザーの情報を追加

## 開発用メモ
無し

