### PR TITLE
Expo Push通知のトークンを保存するAPIを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package.json
 yarn.lock
 node_modules
 .expo-shared
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ go run github.com/99designs/gqlgen generate
 
 ```
 $ rm -rf ./repository/moq.go
-$ moq -out=repository/moq.go ./repository ItemRepositoryInterface UserRepositoryInterface InviteRepositoryInterface RelationshipRequestInterface RelationshipInterface CommonRepositoryInterface
+$ moq -out=repository/moq.go ./repository ItemRepositoryInterface UserRepositoryInterface InviteRepositoryInterface RelationshipRequestInterface RelationshipInterface PushTokenRepositoryInterface CommonRepositoryInterface
 ```
 
 テストを実行

--- a/graph/common_test.go
+++ b/graph/common_test.go
@@ -21,6 +21,7 @@ func newGraph() graph.Graph {
 		InviteRepository:              &repository.InviteRepositoryInterfaceMock{},
 		RelationshipRequestRepository: &repository.RelationshipRequestInterfaceMock{},
 		RelationshipRepository:        &repository.RelationshipInterfaceMock{},
+		PushTokenRepository:           &repository.PushTokenRepositoryInterfaceMock{},
 		CommonRepository:              &repository.CommonRepositoryInterfaceMock{},
 	}
 

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -78,6 +78,7 @@ type ComplexityRoot struct {
 		CreateAuthUser            func(childComplexity int, input model.NewUser) int
 		CreateInvite              func(childComplexity int) int
 		CreateItem                func(childComplexity int, input model.NewItem) int
+		CreatePushToken           func(childComplexity int, input model.NewPushToken) int
 		CreateRelationshipRequest func(childComplexity int, input model.NewRelationshipRequest) int
 		CreateUser                func(childComplexity int, input model.NewUser) int
 		DeleteItem                func(childComplexity int, input model.DeleteItem) int
@@ -91,6 +92,14 @@ type ComplexityRoot struct {
 	PageInfo struct {
 		EndCursor   func(childComplexity int) int
 		HasNextPage func(childComplexity int) int
+	}
+
+	PushToken struct {
+		CreatedAt func(childComplexity int) int
+		DeviceID  func(childComplexity int) int
+		Token     func(childComplexity int) int
+		UpdatedAt func(childComplexity int) int
+		UserID    func(childComplexity int) int
 	}
 
 	Query struct {
@@ -166,6 +175,7 @@ type MutationResolver interface {
 	AcceptRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error)
 	NgRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error)
 	DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error)
+	CreatePushToken(ctx context.Context, input model.NewPushToken) (*model.PushToken, error)
 }
 type QueryResolver interface {
 	User(ctx context.Context) (*model.User, error)
@@ -356,6 +366,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateItem(childComplexity, args["input"].(model.NewItem)), true
 
+	case "Mutation.createPushToken":
+		if e.complexity.Mutation.CreatePushToken == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createPushToken_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreatePushToken(childComplexity, args["input"].(model.NewPushToken)), true
+
 	case "Mutation.createRelationshipRequest":
 		if e.complexity.Mutation.CreateRelationshipRequest == nil {
 			break
@@ -460,6 +482,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PageInfo.HasNextPage(childComplexity), true
+
+	case "PushToken.createdAt":
+		if e.complexity.PushToken.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.PushToken.CreatedAt(childComplexity), true
+
+	case "PushToken.deviceID":
+		if e.complexity.PushToken.DeviceID == nil {
+			break
+		}
+
+		return e.complexity.PushToken.DeviceID(childComplexity), true
+
+	case "PushToken.token":
+		if e.complexity.PushToken.Token == nil {
+			break
+		}
+
+		return e.complexity.PushToken.Token(childComplexity), true
+
+	case "PushToken.updatedAt":
+		if e.complexity.PushToken.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.PushToken.UpdatedAt(childComplexity), true
+
+	case "PushToken.userID":
+		if e.complexity.PushToken.UserID == nil {
+			break
+		}
+
+		return e.complexity.PushToken.UserID(childComplexity), true
 
 	case "Query.invite":
 		if e.complexity.Query.Invite == nil {
@@ -946,6 +1003,19 @@ input InputRelationships {
   first: Int!
 }
 
+type PushToken {
+  "ユーザーID"
+  userID: ID!
+  "Push通知トークン"
+  token: String!
+  "デバイスID"
+  deviceID: String!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+}
+
 type Query {
   "ユーザーを取得する"
   user: User!
@@ -1013,6 +1083,13 @@ input NewRelationshipRequest {
   code: String!
 }
 
+input NewPushToken {
+  "Push通知トークン"
+  token: String!
+  "デバイスID"
+  deviceID: String!
+}
+
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
@@ -1040,6 +1117,8 @@ type Mutation {
   ngRelationshipRequest(followedID: String!): RelationshipRequest!
   "共有メンバーを解除する"
   deleteRelationship(followedID: String!): Relationship!
+  "Push通知のトークンを作成する"
+  createPushToken(input: NewPushToken!): PushToken!
 }
 
 scalar Time
@@ -1088,6 +1167,21 @@ func (ec *executionContext) field_Mutation_createItem_args(ctx context.Context, 
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNNewItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewItem(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createPushToken_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.NewPushToken
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNNewPushToken2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewPushToken(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2471,6 +2565,48 @@ func (ec *executionContext) _Mutation_deleteRelationship(ctx context.Context, fi
 	return ec.marshalNRelationship2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Mutation_createPushToken(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_createPushToken_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreatePushToken(rctx, args["input"].(model.NewPushToken))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PushToken)
+	fc.Result = res
+	return ec.marshalNPushToken2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐPushToken(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _PageInfo_endCursor(ctx context.Context, field graphql.CollectedField, obj *model.PageInfo) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -2539,6 +2675,181 @@ func (ec *executionContext) _PageInfo_hasNextPage(ctx context.Context, field gra
 	res := resTmp.(bool)
 	fc.Result = res
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PushToken_userID(ctx context.Context, field graphql.CollectedField, obj *model.PushToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "PushToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PushToken_token(ctx context.Context, field graphql.CollectedField, obj *model.PushToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "PushToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Token, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PushToken_deviceID(ctx context.Context, field graphql.CollectedField, obj *model.PushToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "PushToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeviceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PushToken_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.PushToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "PushToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _PushToken_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.PushToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "PushToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_user(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -5138,6 +5449,34 @@ func (ec *executionContext) unmarshalInputNewItem(ctx context.Context, obj inter
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputNewPushToken(ctx context.Context, obj interface{}) (model.NewPushToken, error) {
+	var it model.NewPushToken
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "token":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("token"))
+			it.Token, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "deviceID":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deviceID"))
+			it.DeviceID, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputNewRelationshipRequest(ctx context.Context, obj interface{}) (model.NewRelationshipRequest, error) {
 	var it model.NewRelationshipRequest
 	var asMap = obj.(map[string]interface{})
@@ -5519,6 +5858,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "createPushToken":
+			out.Values[i] = ec._Mutation_createPushToken(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -5548,6 +5892,53 @@ func (ec *executionContext) _PageInfo(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "hasNextPage":
 			out.Values[i] = ec._PageInfo_hasNextPage(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var pushTokenImplementors = []string{"PushToken"}
+
+func (ec *executionContext) _PushToken(ctx context.Context, sel ast.SelectionSet, obj *model.PushToken) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, pushTokenImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PushToken")
+		case "userID":
+			out.Values[i] = ec._PushToken_userID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "token":
+			out.Values[i] = ec._PushToken_token(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deviceID":
+			out.Values[i] = ec._PushToken_deviceID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._PushToken_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._PushToken_updatedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -6385,6 +6776,11 @@ func (ec *executionContext) unmarshalNNewItem2githubᚗcomᚋwheatandcatᚋmemoi
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNNewPushToken2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewPushToken(ctx context.Context, v interface{}) (model.NewPushToken, error) {
+	res, err := ec.unmarshalInputNewPushToken(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNNewRelationshipRequest2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewRelationshipRequest(ctx context.Context, v interface{}) (model.NewRelationshipRequest, error) {
 	res, err := ec.unmarshalInputNewRelationshipRequest(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -6403,6 +6799,20 @@ func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋwheatandcatᚋmem
 		return graphql.Null
 	}
 	return ec._PageInfo(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPushToken2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐPushToken(ctx context.Context, sel ast.SelectionSet, v model.PushToken) graphql.Marshaler {
+	return ec._PushToken(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPushToken2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐPushToken(ctx context.Context, sel ast.SelectionSet, v *model.PushToken) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PushToken(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNRelationship2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐRelationship(ctx context.Context, sel ast.SelectionSet, v model.Relationship) graphql.Marshaler {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -9,6 +9,7 @@ type Application struct {
 	InviteRepository              repository.InviteRepositoryInterface
 	RelationshipRequestRepository repository.RelationshipRequestInterface
 	RelationshipRepository        repository.RelationshipInterface
+	PushTokenRepository           repository.PushTokenRepositoryInterface
 	CommonRepository              repository.CommonRepositoryInterface
 }
 
@@ -20,6 +21,7 @@ func NewApplication() *Application {
 		InviteRepository:              repository.NewInviteRepository(),
 		RelationshipRequestRepository: repository.NewRelationshipRequestRepository(),
 		RelationshipRepository:        repository.NewRelationshipRepository(),
+		PushTokenRepository:           repository.NewPushTokenRepository(),
 		CommonRepository:              repository.NewCommonRepository(),
 	}
 }

--- a/graph/item_test.go
+++ b/graph/item_test.go
@@ -89,6 +89,14 @@ func TestGetItemsInPeriod(t *testing.T) {
 		UpdatedAt:  date,
 	}}
 
+	rr := []*model.Relationship{{
+		ID:         "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		FollowerID: "test",
+		FollowedID: "test",
+		CreatedAt:  date,
+		UpdatedAt:  date,
+	}}
+
 	g := newGraph()
 
 	itemRepositoryMock := &repository.ItemRepositoryInterfaceMock{
@@ -97,7 +105,14 @@ func TestGetItemsInPeriod(t *testing.T) {
 		},
 	}
 
+	relationshipRepositoryMock := &repository.RelationshipInterfaceMock{
+		FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipCursor) ([]*model.Relationship, error) {
+			return rr, nil
+		},
+	}
+
 	g.App.ItemRepository = itemRepositoryMock
+	g.App.RelationshipRepository = relationshipRepositoryMock
 	after := ""
 
 	iipe := []*model.ItemsInPeriodEdge{{

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -79,6 +79,13 @@ type NewItem struct {
 	Dislike bool      `json:"dislike"`
 }
 
+type NewPushToken struct {
+	// Push通知トークン
+	Token string `json:"token"`
+	// デバイスID
+	DeviceID string `json:"deviceID"`
+}
+
 type NewRelationshipRequest struct {
 	// 招待コード
 	Code string `json:"code"`
@@ -92,6 +99,19 @@ type NewUser struct {
 type PageInfo struct {
 	EndCursor   string `json:"endCursor"`
 	HasNextPage bool   `json:"hasNextPage"`
+}
+
+type PushToken struct {
+	// ユーザーID
+	UserID string `json:"userID"`
+	// Push通知トークン
+	Token string `json:"token"`
+	// デバイスID
+	DeviceID string `json:"deviceID"`
+	// 作成日時
+	CreatedAt time.Time `json:"createdAt"`
+	// 更新日時
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 type Relationship struct {

--- a/graph/push_token.go
+++ b/graph/push_token.go
@@ -1,0 +1,24 @@
+package graph
+
+import (
+	"context"
+
+	"github.com/wheatandcat/memoir-backend/graph/model"
+)
+
+// PushToken トークン作成
+func (g *Graph) CreatePushToken(ctx context.Context, input *model.NewPushToken) (*model.PushToken, error) {
+	i := &model.PushToken{
+		UserID:    g.UserID,
+		Token:     input.Token,
+		DeviceID:  input.DeviceID,
+		CreatedAt: g.Client.Time.Now(),
+		UpdatedAt: g.Client.Time.Now(),
+	}
+
+	if err := g.App.PushTokenRepository.Create(ctx, g.FirestoreClient, g.UserID, i); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}

--- a/graph/push_token_test.go
+++ b/graph/push_token_test.go
@@ -1,0 +1,72 @@
+package graph_test
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/google/go-cmp/cmp"
+	"github.com/wheatandcat/memoir-backend/client/timegen"
+	"github.com/wheatandcat/memoir-backend/client/uuidgen"
+	"github.com/wheatandcat/memoir-backend/graph"
+	"github.com/wheatandcat/memoir-backend/graph/model"
+	"github.com/wheatandcat/memoir-backend/repository"
+	"gopkg.in/go-playground/assert.v1"
+)
+
+func TestCreatePushToken(t *testing.T) {
+	ctx := context.Background()
+
+	client := &graph.Client{
+		UUID: &uuidgen.UUID{},
+		Time: &timegen.Time{},
+	}
+
+	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
+
+	pushToken := &model.PushToken{
+		UserID:    "test",
+		Token:     "token",
+		DeviceID:  "deviceID",
+		CreatedAt: date,
+		UpdatedAt: date,
+	}
+
+	g := newGraph()
+
+	pushTokenRepositoryMock := &repository.PushTokenRepositoryInterfaceMock{
+		CreateFunc: func(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error {
+			return nil
+		},
+	}
+
+	g.App.PushTokenRepository = pushTokenRepositoryMock
+
+	tests := []struct {
+		name   string
+		param  *model.NewPushToken
+		result *model.PushToken
+	}{
+		{
+			name: "Pushトークンを作成する",
+			param: &model.NewPushToken{
+				Token:    "token",
+				DeviceID: "deviceID",
+			},
+			result: pushToken,
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			r, _ := g.CreatePushToken(ctx, td.param)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+		})
+	}
+
+}

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -129,6 +129,19 @@ input InputRelationships {
   first: Int!
 }
 
+type PushToken {
+  "ユーザーID"
+  userID: ID!
+  "Push通知トークン"
+  token: String!
+  "デバイスID"
+  deviceID: String!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+}
+
 type Query {
   "ユーザーを取得する"
   user: User!
@@ -196,6 +209,13 @@ input NewRelationshipRequest {
   code: String!
 }
 
+input NewPushToken {
+  "Push通知トークン"
+  token: String!
+  "デバイスID"
+  deviceID: String!
+}
+
 type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
@@ -223,6 +243,8 @@ type Mutation {
   ngRelationshipRequest(followedID: String!): RelationshipRequest!
   "共有メンバーを解除する"
   deleteRelationship(followedID: String!): Relationship!
+  "Push通知のトークンを作成する"
+  createPushToken(input: NewPushToken!): PushToken!
 }
 
 scalar Time

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -5,7 +5,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -174,6 +173,21 @@ func (r *mutationResolver) DeleteRelationship(ctx context.Context, followedID st
 	return result, nil
 }
 
+func (r *mutationResolver) CreatePushToken(ctx context.Context, input model.NewPushToken) (*model.PushToken, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := g.CreatePushToken(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+
+}
+
 func (r *queryResolver) User(ctx context.Context) (*model.User, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
@@ -324,16 +338,3 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *mutationResolver) AcceptRelationship(ctx context.Context, id string) (*model.Relationship, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-func (r *mutationResolver) NgRelationship(ctx context.Context, id string) (*model.Relationship, error) {
-	panic(fmt.Errorf("not implemented"))
-}

--- a/repository/moq.go
+++ b/repository/moq.go
@@ -1689,6 +1689,89 @@ func (mock *RelationshipInterfaceMock) FindByFollowedIDCalls() []struct {
 	return calls
 }
 
+// Ensure, that PushTokenRepositoryInterfaceMock does implement PushTokenRepositoryInterface.
+// If this is not the case, regenerate this file with moq.
+var _ PushTokenRepositoryInterface = &PushTokenRepositoryInterfaceMock{}
+
+// PushTokenRepositoryInterfaceMock is a mock implementation of PushTokenRepositoryInterface.
+//
+// 	func TestSomethingThatUsesPushTokenRepositoryInterface(t *testing.T) {
+//
+// 		// make and configure a mocked PushTokenRepositoryInterface
+// 		mockedPushTokenRepositoryInterface := &PushTokenRepositoryInterfaceMock{
+// 			CreateFunc: func(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error {
+// 				panic("mock out the Create method")
+// 			},
+// 		}
+//
+// 		// use mockedPushTokenRepositoryInterface in code that requires PushTokenRepositoryInterface
+// 		// and then make assertions.
+//
+// 	}
+type PushTokenRepositoryInterfaceMock struct {
+	// CreateFunc mocks the Create method.
+	CreateFunc func(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// Create holds details about calls to the Create method.
+		Create []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// UserID is the userID argument value.
+			UserID string
+			// I is the i argument value.
+			I *model.PushToken
+		}
+	}
+	lockCreate sync.RWMutex
+}
+
+// Create calls CreateFunc.
+func (mock *PushTokenRepositoryInterfaceMock) Create(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error {
+	if mock.CreateFunc == nil {
+		panic("PushTokenRepositoryInterfaceMock.CreateFunc: method is nil but PushTokenRepositoryInterface.Create was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+		I      *model.PushToken
+	}{
+		Ctx:    ctx,
+		F:      f,
+		UserID: userID,
+		I:      i,
+	}
+	mock.lockCreate.Lock()
+	mock.calls.Create = append(mock.calls.Create, callInfo)
+	mock.lockCreate.Unlock()
+	return mock.CreateFunc(ctx, f, userID, i)
+}
+
+// CreateCalls gets all the calls that were made to Create.
+// Check the length with:
+//     len(mockedPushTokenRepositoryInterface.CreateCalls())
+func (mock *PushTokenRepositoryInterfaceMock) CreateCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	UserID string
+	I      *model.PushToken
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+		I      *model.PushToken
+	}
+	mock.lockCreate.RLock()
+	calls = mock.calls.Create
+	mock.lockCreate.RUnlock()
+	return calls
+}
+
 // Ensure, that CommonRepositoryInterfaceMock does implement CommonRepositoryInterface.
 // If this is not the case, regenerate this file with moq.
 var _ CommonRepositoryInterface = &CommonRepositoryInterfaceMock{}

--- a/repository/push_token.go
+++ b/repository/push_token.go
@@ -1,0 +1,30 @@
+package repository
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/wheatandcat/memoir-backend/graph/model"
+)
+
+type PushTokenRepositoryInterface interface {
+	Create(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error
+}
+
+type PushTokenRepository struct {
+}
+
+// NewPushTokenRepository is Create new PushTokenRepository
+func NewPushTokenRepository() PushTokenRepositoryInterface {
+	return &PushTokenRepository{}
+}
+
+func getPushTokenCollection(f *firestore.Client, userID string) *firestore.CollectionRef {
+	return f.Collection("users/" + userID + "/pushToken")
+}
+
+func (re *PushTokenRepository) Create(ctx context.Context, f *firestore.Client, userID string, i *model.PushToken) error {
+	_, err := getPushTokenCollection(f, userID).Doc(i.DeviceID).Set(ctx, i)
+
+	return err
+}

--- a/schema.md
+++ b/schema.md
@@ -13,6 +13,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
     * [ItemsInPeriod](#itemsinperiod)
     * [ItemsInPeriodEdge](#itemsinperiodedge)
     * [PageInfo](#pageinfo)
+    * [PushToken](#pushtoken)
     * [Relationship](#relationship)
     * [RelationshipEdge](#relationshipedge)
     * [RelationshipRequest](#relationshiprequest)
@@ -26,6 +27,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
     * [InputRelationshipRequests](#inputrelationshiprequests)
     * [InputRelationships](#inputrelationships)
     * [NewItem](#newitem)
+    * [NewPushToken](#newpushtoken)
     * [NewRelationshipRequest](#newrelationshiprequest)
     * [NewUser](#newuser)
     * [UpdateItem](#updateitem)
@@ -339,6 +341,20 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td valign="top"><a href="#string">String</a>!</td>
 <td></td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>createPushToken</strong></td>
+<td valign="top"><a href="#pushtoken">PushToken</a>!</td>
+<td>
+
+Push通知のトークンを作成する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">input</td>
+<td valign="top"><a href="#newpushtoken">NewPushToken</a>!</td>
+<td></td>
+</tr>
 </tbody>
 </table>
 
@@ -554,6 +570,66 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td colspan="2" valign="top"><strong>hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td></td>
+</tr>
+</tbody>
+</table>
+
+### PushToken
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>userID</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Push通知トークン
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deviceID</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+デバイスID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createdAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+作成日時
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+更新日時
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -1033,6 +1109,38 @@ ID
 </tbody>
 </table>
 
+### NewPushToken
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Push通知トークン
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deviceID</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+デバイスID
+
+</td>
+</tr>
+</tbody>
+</table>
+
 ### NewRelationshipRequest
 
 <table>
@@ -1194,3 +1302,5 @@ The `Int` scalar type represents non-fractional signed whole numeric values. Int
 The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
 
 ### Time
+
+Done in 2.56s.


### PR DESCRIPTION
## 関連 issue

- fixes #50 

## 対応内容


以下のGraphQL
 - Mutation
   - createPushToken: Push通知のトークンを作成する 

## 開発用メモ
無し

