### PR TITLE
CreateAuthUserでUserIDが新規作成を判別できるように修正

### DIFF
--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -89,6 +89,15 @@ type ComplexityRoot struct {
 		UpdateUser                func(childComplexity int, input model.UpdateUser) int
 	}
 
+	NewAuthUser struct {
+		CreatedAt   func(childComplexity int) int
+		DisplayName func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Image       func(childComplexity int) int
+		New         func(childComplexity int) int
+		UpdatedAt   func(childComplexity int) int
+	}
+
 	PageInfo struct {
 		EndCursor   func(childComplexity int) int
 		HasNextPage func(childComplexity int) int
@@ -164,7 +173,7 @@ type ComplexityRoot struct {
 
 type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.NewUser) (*model.User, error)
-	CreateAuthUser(ctx context.Context, input model.NewUser) (*model.User, error)
+	CreateAuthUser(ctx context.Context, input model.NewUser) (*model.NewAuthUser, error)
 	UpdateUser(ctx context.Context, input model.UpdateUser) (*model.User, error)
 	CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error)
 	UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error)
@@ -468,6 +477,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.UpdateUser(childComplexity, args["input"].(model.UpdateUser)), true
+
+	case "NewAuthUser.createdAt":
+		if e.complexity.NewAuthUser.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.CreatedAt(childComplexity), true
+
+	case "NewAuthUser.displayName":
+		if e.complexity.NewAuthUser.DisplayName == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.DisplayName(childComplexity), true
+
+	case "NewAuthUser.id":
+		if e.complexity.NewAuthUser.ID == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.ID(childComplexity), true
+
+	case "NewAuthUser.image":
+		if e.complexity.NewAuthUser.Image == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.Image(childComplexity), true
+
+	case "NewAuthUser.new":
+		if e.complexity.NewAuthUser.New == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.New(childComplexity), true
+
+	case "NewAuthUser.updatedAt":
+		if e.complexity.NewAuthUser.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.NewAuthUser.UpdatedAt(childComplexity), true
 
 	case "PageInfo.endCursor":
 		if e.complexity.PageInfo.EndCursor == nil {
@@ -894,6 +945,21 @@ type User {
   updatedAt: Time!
 }
 
+type NewAuthUser {
+  "ユーザーID"
+  id: ID!
+  "表示名"
+  displayName: String!
+  "画像URL"
+  image: String!
+  "新規作成"
+  new: Boolean!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+}
+
 type Invite {
   "ユーザーID"
   userID: ID!
@@ -1094,7 +1160,7 @@ type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
   "認証ユーザーを作成する"
-  createAuthUser(input: NewUser!): User!
+  createAuthUser(input: NewUser!): NewAuthUser!
   "ユーザーを更新する"
   updateUser(input: UpdateUser!): User!
   "アイテムを作成する"
@@ -2154,9 +2220,9 @@ func (ec *executionContext) _Mutation_createAuthUser(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.User)
+	res := resTmp.(*model.NewAuthUser)
 	fc.Result = res
-	return ec.marshalNUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+	return ec.marshalNNewAuthUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewAuthUser(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2605,6 +2671,216 @@ func (ec *executionContext) _Mutation_createPushToken(ctx context.Context, field
 	res := resTmp.(*model.PushToken)
 	fc.Result = res
 	return ec.marshalNPushToken2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐPushToken(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_id(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_displayName(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_image(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Image, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_new(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.New, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_createdAt(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NewAuthUser_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model.NewAuthUser) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NewAuthUser",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PageInfo_endCursor(ctx context.Context, field graphql.CollectedField, obj *model.PageInfo) (ret graphql.Marshaler) {
@@ -5874,6 +6150,58 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 	return out
 }
 
+var newAuthUserImplementors = []string{"NewAuthUser"}
+
+func (ec *executionContext) _NewAuthUser(ctx context.Context, sel ast.SelectionSet, obj *model.NewAuthUser) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, newAuthUserImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("NewAuthUser")
+		case "id":
+			out.Values[i] = ec._NewAuthUser_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "displayName":
+			out.Values[i] = ec._NewAuthUser_displayName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "image":
+			out.Values[i] = ec._NewAuthUser_image(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "new":
+			out.Values[i] = ec._NewAuthUser_new(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._NewAuthUser_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._NewAuthUser_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var pageInfoImplementors = []string{"PageInfo"}
 
 func (ec *executionContext) _PageInfo(ctx context.Context, sel ast.SelectionSet, obj *model.PageInfo) graphql.Marshaler {
@@ -6769,6 +7097,20 @@ func (ec *executionContext) marshalNItemsInPeriodEdge2ᚖgithubᚗcomᚋwheatand
 		return graphql.Null
 	}
 	return ec._ItemsInPeriodEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNNewAuthUser2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewAuthUser(ctx context.Context, sel ast.SelectionSet, v model.NewAuthUser) graphql.Marshaler {
+	return ec._NewAuthUser(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNNewAuthUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewAuthUser(ctx context.Context, sel ast.SelectionSet, v *model.NewAuthUser) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._NewAuthUser(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNNewItem2githubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐNewItem(ctx context.Context, v interface{}) (model.NewItem, error) {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -68,6 +68,21 @@ type ItemsInPeriodEdge struct {
 	Cursor string `json:"cursor"`
 }
 
+type NewAuthUser struct {
+	// ユーザーID
+	ID string `json:"id"`
+	// 表示名
+	DisplayName string `json:"displayName"`
+	// 画像URL
+	Image string `json:"image"`
+	// 新規作成
+	New bool `json:"new"`
+	// 作成日時
+	CreatedAt time.Time `json:"createdAt"`
+	// 更新日時
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
 type NewItem struct {
 	// タイトル
 	Title string `json:"title"`

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -20,6 +20,21 @@ type User {
   updatedAt: Time!
 }
 
+type NewAuthUser {
+  "ユーザーID"
+  id: ID!
+  "表示名"
+  displayName: String!
+  "画像URL"
+  image: String!
+  "新規作成"
+  new: Boolean!
+  "作成日時"
+  createdAt: Time!
+  "更新日時"
+  updatedAt: Time!
+}
+
 type Invite {
   "ユーザーID"
   userID: ID!
@@ -220,7 +235,7 @@ type Mutation {
   "ユーザーを作成する"
   createUser(input: NewUser!): User!
   "認証ユーザーを作成する"
-  createAuthUser(input: NewUser!): User!
+  createAuthUser(input: NewUser!): NewAuthUser!
   "ユーザーを更新する"
   updateUser(input: UpdateUser!): User!
   "アイテムを作成する"

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -23,7 +23,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) 
 	return result, nil
 }
 
-func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewUser) (*model.User, error) {
+func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewUser) (*model.NewAuthUser, error) {
 	g := NewGraphWithSetUserID(r.App, r.FirestoreClient, "")
 	result, err := g.CreateAuthUser(ctx, &input)
 	if err != nil {
@@ -185,7 +185,6 @@ func (r *mutationResolver) CreatePushToken(ctx context.Context, input model.NewP
 	}
 
 	return result, nil
-
 }
 
 func (r *queryResolver) User(ctx context.Context) (*model.User, error) {

--- a/graph/user.go
+++ b/graph/user.go
@@ -24,7 +24,7 @@ func (g *Graph) CreateUser(ctx context.Context, input *model.NewUser) (*model.Us
 }
 
 // CreateAuthUser 認証済みユーザーを作成
-func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewUser) (*model.User, error) {
+func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewUser) (*model.NewAuthUser, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
 		return nil, fmt.Errorf("invalid authorization")
 	}
@@ -35,7 +35,7 @@ func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewUser) (*mode
 		UpdatedAt:   g.Client.Time.Now(),
 	}
 
-	mu := &model.User{
+	mu := &model.NewAuthUser{
 		ID: input.ID,
 	}
 


### PR DESCRIPTION
## 関連 issue

- fixes #57 

## 対応内容
 - 新作成とログインで導線を変わるので、レスポンスを変更

## 開発用メモ
無し

