### PR TITLE
relationshipsをログイン前にアクセスした場合は空配列を返す

### DIFF
--- a/graph/relationship.go
+++ b/graph/relationship.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
@@ -36,11 +37,16 @@ func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*mod
 	return r1, nil
 }
 
-// GetRelationships 共有の招待リクエストを取得する
+// GetRelationships 共有ユーザーを取得する
 func (g *Graph) GetRelationships(ctx context.Context, input model.InputRelationships, userSkip bool) (*model.Relationships, error) {
 	t := g.Client.Time
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		log.Println("OK")
+		ibp := &model.Relationships{
+			PageInfo: &model.PageInfo{},
+			Edges:    []*model.RelationshipEdge{},
+		}
+		return ibp, nil
 	}
 
 	cursor := repository.RelationshipCursor{


### PR DESCRIPTION
## 関連 issue

- fixes #61 

## 対応内容

<img width="680" alt="スクリーンショット 2021-08-20 21 45 55" src="https://user-images.githubusercontent.com/19209314/130235680-9403fedb-a8cf-4e3b-8de6-6c04ce38716b.png">

 - ログインしていない状態でmemoir画面に遷移するとエラーになるので空を返すように修正


## 開発用メモ
無し

