### PR TITLE
review環境にデプロイ時にSentryにReleaseバージョンを設定する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ env:
   REVIEW_APP_YAML: ${{ secrets.REVIEW_APP_YAML }}
   SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
   GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
-  RELEASE_INSTANCE_VERSION: "release"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -30,7 +29,7 @@ jobs:
     - name: Get current date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+    - name: set env
+      run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
-      run: |
-        echo "release${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
-        gcloud app deploy --quiet app.yaml --version=$RELEASE_INSTANCE_VERSION
+      run: gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         export_default_credentials: true
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H%M%S')"
     - name: set env
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,5 +33,5 @@ jobs:
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
       run: |
-        echo "env_variables:\n RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
-
+        echo "env_variables:\n  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
+        gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,5 +33,6 @@ jobs:
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
       run: |
-        echo "env_variables:\n  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
+        echo -e "env_variables:\n  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
         cat release.yaml
+        gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,5 @@ jobs:
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
       run: |
-        echo \
-        "env_variables\n" \
-        "  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> ./release.yaml
+        echo "env_variables:\n RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
         gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
+  push
+
 env:
   REVIEW_APP_YAML: ${{ secrets.REVIEW_APP_YAML }}
   SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
@@ -21,12 +20,16 @@ jobs:
       run: echo $SERVICE_ACCOUNT_JSON | base64 --decode -i > ./serviceAccount.json
     - name: Create gcpServiceAccount.json file
       run: echo $GCP_SERVICE_ACCOUNT_JSON | base64 --decode -i > ./gcpServiceAccount.json
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
         export_default_credentials: true
-
     - name: Use gcloud CLI
-      run: gcloud app deploy --quiet app.yaml
+      run: |
+        echo "release-${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
+        gcloud app deploy --quiet app.yaml -v $RELEASE_INSTANCE_VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         export_default_credentials: true
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H%M%S')"
+      run: echo "::set-output name=date::$(date +'%Y%m%d%H%M%S')"
     - name: set env
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,6 @@ jobs:
     - name: set env
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
-      run: gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}
+      run: |
+        export RELEASE_INSTANCE_VERSION=${{ env.release_version }}
+        gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy
 
 on:
-  push
-
+  push:
+    branches:
+      - main
 env:
   REVIEW_APP_YAML: ${{ secrets.REVIEW_APP_YAML }}
   SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,3 @@ jobs:
       run: |
         echo "env_variables:\n  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
         cat release.yaml
-        gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,5 @@ jobs:
     - name: Use gcloud CLI
       run: |
         echo "env_variables:\n  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
+        cat release.yaml
         gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,5 +33,7 @@ jobs:
       run: echo "release_version=release${{ steps.date.outputs.date }}" >> $GITHUB_ENV
     - name: Use gcloud CLI
       run: |
-        export RELEASE_INSTANCE_VERSION=${{ env.release_version }}
+        echo \
+        "env_variables\n" \
+        "  RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> ./release.yaml
         gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Get current date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
-    - name: set env
-      run: echo "release${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
     - name: Use gcloud CLI
-      run: gcloud app deploy --quiet app.yaml 
+      run: |
+        echo "release${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
+        gcloud app deploy --quiet app.yaml --version=$RELEASE_INSTANCE_VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ env:
   REVIEW_APP_YAML: ${{ secrets.REVIEW_APP_YAML }}
   SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
   GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
-  RELEASE_INSTANCE_VERSION: "release-"
+  RELEASE_INSTANCE_VERSION: "release"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,16 +21,16 @@ jobs:
       run: echo $SERVICE_ACCOUNT_JSON | base64 --decode -i > ./serviceAccount.json
     - name: Create gcpServiceAccount.json file
       run: echo $GCP_SERVICE_ACCOUNT_JSON | base64 --decode -i > ./gcpServiceAccount.json
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
-    - name: set env
-      run: echo "release-${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@master
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
         export_default_credentials: true
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+    - name: set env
+      run: echo "release${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
     - name: Use gcloud CLI
-      run: gcloud app deploy --quiet app.yaml -v $RELEASE_INSTANCE_VERSION
+      run: gcloud app deploy --quiet app.yaml 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Use gcloud CLI
       run: |
         echo "env_variables:\n RELEASE_INSTANCE_VERSION: ${{ env.release_version }}" >> release.yaml
-        gcloud app deploy --quiet app.yaml --version=${{ env.release_version }}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Get current date
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+    - name: set env
+      run: echo "release-${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@master
       with:
@@ -31,6 +33,4 @@ jobs:
         service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
         export_default_credentials: true
     - name: Use gcloud CLI
-      run: |
-        echo "release-${{ steps.date.outputs.date }}" >> $RELEASE_INSTANCE_VERSION
-        gcloud app deploy --quiet app.yaml -v $RELEASE_INSTANCE_VERSION
+      run: gcloud app deploy --quiet app.yaml -v $RELEASE_INSTANCE_VERSION

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ env:
   REVIEW_APP_YAML: ${{ secrets.REVIEW_APP_YAML }}
   SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
   GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+  RELEASE_INSTANCE_VERSION: "release-"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,7 +23,7 @@ jobs:
       run: echo $GCP_SERVICE_ACCOUNT_JSON | base64 --decode -i > ./gcpServiceAccount.json
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@master
       with:

--- a/app.go
+++ b/app.go
@@ -21,8 +21,6 @@ import (
 const defaultPort = "8080"
 
 func main() {
-	log.Println("RELEASE_INSTANCE_VERSION:", os.Getenv("RELEASE_INSTANCE_VERSION"))
-
 	sco := sentry.ClientOptions{
 		Dsn: os.Getenv("SENTRY_DSN"),
 	}

--- a/app.go
+++ b/app.go
@@ -21,9 +21,16 @@ import (
 const defaultPort = "8080"
 
 func main() {
-	err := sentry.Init(sentry.ClientOptions{
+	log.Println("RELEASE_INSTANCE_VERSION:", os.Getenv("RELEASE_INSTANCE_VERSION"))
+
+	sco := sentry.ClientOptions{
 		Dsn: os.Getenv("SENTRY_DSN"),
-	})
+	}
+	if os.Getenv("APP_ENV") != "local" {
+		sco.Release = os.Getenv("RELEASE_INSTANCE_VERSION")
+	}
+
+	err := sentry.Init(sco)
 	if err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}


### PR DESCRIPTION
## 関連 issue

- fixes #70 

## 対応内容

 - Sentryの[Releases](https://docs.sentry.io/platforms/go/configuration/releases/)がGAEのインスタンスのバージョンと同期するように修正

<img width="1332" alt="スクリーンショット 2021-09-19 21 50 25" src="https://user-images.githubusercontent.com/19209314/133928127-c0d7a4b0-13bb-4651-8217-0306ec5318d1.png">

## 開発用メモ
無し

