### PR TITLE
air導入②

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -3,7 +3,7 @@ tmp_dir = "tmp"
 
 [build]
   bin = "./tmp/main"
-  cmd = "go run app.go"
+  cmd = "go build -o ./tmp/main ."
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "node_modules", ".expo-shared"]
   exclude_file = []

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -23,3 +23,5 @@
 *.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+.env
+envenb.go

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ node_modules
 .expo-shared
 .DS_Store
 .envrc
-tmp/build-errors.log
+tmp/
+.env

--- a/app.go
+++ b/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/getsentry/sentry-go"
 	"github.com/go-chi/chi"
+	"github.com/joho/godotenv"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/wheatandcat/memoir-backend/auth"
 	"github.com/wheatandcat/memoir-backend/graph"
@@ -21,6 +23,13 @@ import (
 const defaultPort = "8080"
 
 func main() {
+	if os.Getenv("APP_ENV") == "local" {
+		err := godotenv.Load(".env")
+		if err != nil {
+			fmt.Printf("読み込み出来ませんでした: %v", err)
+		}
+	}
+
 	sco := sentry.ClientOptions{
 		Dsn: os.Getenv("SENTRY_DSN"),
 	}

--- a/envenb.go
+++ b/envenb.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+var _ = func() interface{} {
+	var envValues = map[string]string{"APP_ENV": "local"}
+
+	for key, value := range envValues {
+		if err := os.Setenv(key, value); err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	return nil
+}()

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
+	github.com/joho/godotenv v1.4.0
+	github.com/k-motoyan/envenb v0.0.0-20181128144113-56d3b7780ec2 // indirect
 	github.com/matryer/moq v0.2.3 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,12 +214,16 @@ github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
 github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0GqwkjqxNd0u65g=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/k-motoyan/envenb v0.0.0-20181128144113-56d3b7780ec2 h1:tE+KGS40jUHNbW7BwPh+rWL3Zgq7yOJ3lmMhkRvikFM=
+github.com/k-motoyan/envenb v0.0.0-20181128144113-56d3b7780ec2/go.mod h1:xAYD67WFMPNTZ8WOgniXRZ9S9a+eFCpNXDFeAvJv/mE=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=


### PR DESCRIPTION
## 関連 issue

- fixes #75 

## 対応内容
 - air導入時にapp.yamlに設定していた環境変数が取得できなくなっていたので修正
 - ローカル開発時は[godotenv](https://github.com/joho/godotenv)から環境変数を設定するように修正
 - ローカル環境の判定は、[envenb](https://github.com/k-motoyan/envenb)を使用して実装

## 開発用メモ
無し

