### PR TITLE
ローカル開発用にスタックトレースを出力する②

### DIFF
--- a/app.go
+++ b/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -26,7 +25,7 @@ func main() {
 	if os.Getenv("APP_ENV") == "local" {
 		err := godotenv.Load(".env")
 		if err != nil {
-			fmt.Printf("読み込み出来ませんでした: %v", err)
+			log.Fatalf("読み込み出来ませんでした: %v", err)
 		}
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cosmtrek/air v1.27.3 h1:laO93SnYnEiJsH0QIeXyso6FJ5maSNufE5d/MmHKBmk=
 github.com/cosmtrek/air v1.27.3/go.mod h1:vrGZm+zmL5htsEr6YjqLXyjSoelgDQIl/DuOtsWVLeU=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -295,6 +296,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -677,6 +679,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/graph/invite.go
+++ b/graph/invite.go
@@ -6,21 +6,22 @@ import (
 	"strings"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 // CreateInvite 招待を作成する
 func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	if i.UserID == g.UserID {
-		return nil, fmt.Errorf("自身の招待コードです")
+		return nil, ce.CustomError(fmt.Errorf("自身の招待コードです"))
 	}
 
 	uuid := g.Client.UUID.Get()
@@ -37,7 +38,7 @@ func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	g.App.InviteRepository.Create(ctx, g.FirestoreClient, batch, i)
 
 	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -46,12 +47,12 @@ func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 // UpdateInvite 招待を更新する
 func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	uuid := g.Client.UUID.Get()
@@ -65,7 +66,7 @@ func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 	g.App.InviteRepository.Create(ctx, g.FirestoreClient, batch, i)
 
 	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -74,12 +75,12 @@ func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 // GetInviteByUseID ユーザーIDから招待を取得する
 func (g *Graph) GetInviteByUseID(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -88,21 +89,21 @@ func (g *Graph) GetInviteByUseID(ctx context.Context) (*model.Invite, error) {
 // GetInviteByCode コードから招待を取得する
 func (g *Graph) GetInviteByCode(ctx context.Context, code string) (*model.User, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.Find(ctx, g.FirestoreClient, code)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	if i.UserID == "" {
-		return nil, fmt.Errorf("招待コードが見つかりません")
+		return nil, ce.CustomError(fmt.Errorf("招待コードが見つかりません"))
 	}
 
 	u, err := g.App.UserRepository.FindByUID(ctx, g.FirestoreClient, i.UserID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return u, nil

--- a/graph/item.go
+++ b/graph/item.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
 	"github.com/wheatandcat/memoir-backend/repository"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 	"google.golang.org/grpc/codes"
 )
 
@@ -25,7 +26,7 @@ func (g *Graph) CreateItem(ctx context.Context, input *model.NewItem) (*model.It
 	}
 
 	if err := g.App.ItemRepository.Create(ctx, g.FirestoreClient, g.UserID, i); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -40,7 +41,7 @@ func (g *Graph) UpdateItem(ctx context.Context, input *model.UpdateItem) (*model
 	}
 
 	if err := g.App.ItemRepository.Update(ctx, g.FirestoreClient, g.UserID, input, i.UpdatedAt); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -53,7 +54,7 @@ func (g *Graph) DeleteItem(ctx context.Context, input *model.DeleteItem) (*model
 	}
 
 	if err := g.App.ItemRepository.Delete(ctx, g.FirestoreClient, g.UserID, input); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil
@@ -63,7 +64,7 @@ func (g *Graph) DeleteItem(ctx context.Context, input *model.DeleteItem) (*model
 func (g *Graph) GetItem(ctx context.Context, id string) (*model.Item, error) {
 	i, err := g.App.ItemRepository.GetItem(ctx, g.FirestoreClient, g.UserID, id)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	t := g.Client.Time
@@ -79,7 +80,7 @@ func (g *Graph) GetItem(ctx context.Context, id string) (*model.Item, error) {
 func (g *Graph) GetItemsInDate(ctx context.Context, date time.Time) ([]*model.Item, error) {
 	items, err := g.App.ItemRepository.GetItemsInDate(ctx, g.FirestoreClient, g.UserID, date)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	t := g.Client.Time
@@ -108,7 +109,7 @@ func (g *Graph) GetItemsInPeriod(ctx context.Context, input model.InputItemsInPe
 		}
 	} else {
 		if GrpcErrorStatusCode(err) != codes.NotFound {
-			return nil, err
+			return nil, ce.CustomError(err)
 		}
 	}
 
@@ -141,7 +142,7 @@ func (g *Graph) GetItemsInPeriod(ctx context.Context, input model.InputItemsInPe
 
 	items, err := g.App.ItemRepository.GetItemUserMultipleInPeriod(ctx, g.FirestoreClient, userID, input.StartDate, input.EndDate, input.First, cursor)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	var ibpes []*model.ItemsInPeriodEdge

--- a/graph/push_token.go
+++ b/graph/push_token.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 // PushToken トークン作成
@@ -17,7 +18,7 @@ func (g *Graph) CreatePushToken(ctx context.Context, input *model.NewPushToken) 
 	}
 
 	if err := g.App.PushTokenRepository.Create(ctx, g.FirestoreClient, g.UserID, i); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil

--- a/graph/relationship.go
+++ b/graph/relationship.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
 	"github.com/wheatandcat/memoir-backend/repository"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 // DeleteRelationship 共有ユーザーを解除する
 func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	batch := g.FirestoreClient.Batch()
@@ -30,7 +31,7 @@ func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*mod
 	g.App.RelationshipRepository.Delete(ctx, g.FirestoreClient, batch, r2)
 
 	if err := g.App.CommonRepository.Commit(ctx, batch); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return r1, nil
@@ -62,7 +63,7 @@ func (g *Graph) GetRelationships(ctx context.Context, input model.InputRelations
 
 	items, err := g.App.RelationshipRepository.FindByFollowedID(ctx, g.FirestoreClient, g.UserID, input.First, cursor)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	userID := []string{}
@@ -74,7 +75,7 @@ func (g *Graph) GetRelationships(ctx context.Context, input model.InputRelations
 	if !userSkip && len(userID) > 0 {
 		users, err = g.App.UserRepository.FindInUID(ctx, g.FirestoreClient, userID)
 		if err != nil {
-			return nil, err
+			return nil, ce.CustomError(err)
 		}
 
 	}

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/wheatandcat/memoir-backend/graph/generated"
 	"github.com/wheatandcat/memoir-backend/graph/model"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) (*model.User, error) {
@@ -17,7 +18,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) 
 	result, err := g.CreateUser(ctx, &input)
 
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -27,7 +28,7 @@ func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewAu
 	g := NewGraphWithSetUserID(r.App, r.FirestoreClient, "")
 	result, err := g.CreateAuthUser(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -36,12 +37,12 @@ func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewAu
 func (r *mutationResolver) UpdateUser(ctx context.Context, input model.UpdateUser) (*model.User, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.UpdateUser(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -50,12 +51,12 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input model.UpdateUse
 func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.CreateItem(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -64,12 +65,12 @@ func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) 
 func (r *mutationResolver) UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.UpdateItem(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -78,12 +79,12 @@ func (r *mutationResolver) UpdateItem(ctx context.Context, input model.UpdateIte
 func (r *mutationResolver) DeleteItem(ctx context.Context, input model.DeleteItem) (*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.DeleteItem(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -92,12 +93,12 @@ func (r *mutationResolver) DeleteItem(ctx context.Context, input model.DeleteIte
 func (r *mutationResolver) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.CreateInvite(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -106,12 +107,12 @@ func (r *mutationResolver) CreateInvite(ctx context.Context) (*model.Invite, err
 func (r *mutationResolver) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.UpdateInvite(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -120,12 +121,12 @@ func (r *mutationResolver) UpdateInvite(ctx context.Context) (*model.Invite, err
 func (r *mutationResolver) CreateRelationshipRequest(ctx context.Context, input model.NewRelationshipRequest) (*model.RelationshipRequest, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.CreateRelationshipRequest(ctx, input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -134,12 +135,12 @@ func (r *mutationResolver) CreateRelationshipRequest(ctx context.Context, input 
 func (r *mutationResolver) AcceptRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.AcceptRelationshipRequest(ctx, followedID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -148,12 +149,12 @@ func (r *mutationResolver) AcceptRelationshipRequest(ctx context.Context, follow
 func (r *mutationResolver) NgRelationshipRequest(ctx context.Context, followedID string) (*model.RelationshipRequest, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.NgRelationshipRequest(ctx, followedID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -162,12 +163,12 @@ func (r *mutationResolver) NgRelationshipRequest(ctx context.Context, followedID
 func (r *mutationResolver) DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.DeleteRelationship(ctx, followedID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -176,12 +177,12 @@ func (r *mutationResolver) DeleteRelationship(ctx context.Context, followedID st
 func (r *mutationResolver) CreatePushToken(ctx context.Context, input model.NewPushToken) (*model.PushToken, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.CreatePushToken(ctx, &input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -190,12 +191,12 @@ func (r *mutationResolver) CreatePushToken(ctx context.Context, input model.NewP
 func (r *queryResolver) User(ctx context.Context) (*model.User, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -206,7 +207,7 @@ func (r *queryResolver) ExistAuthUser(ctx context.Context) (*model.ExistAuthUser
 
 	result, err := g.ExistAuthUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -215,12 +216,12 @@ func (r *queryResolver) ExistAuthUser(ctx context.Context) (*model.ExistAuthUser
 func (r *queryResolver) Item(ctx context.Context, id string) (*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetItem(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -229,12 +230,12 @@ func (r *queryResolver) Item(ctx context.Context, id string) (*model.Item, error
 func (r *queryResolver) ItemsByDate(ctx context.Context, date time.Time) ([]*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetItemsInDate(ctx, date)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -243,12 +244,12 @@ func (r *queryResolver) ItemsByDate(ctx context.Context, date time.Time) ([]*mod
 func (r *queryResolver) ItemsInDate(ctx context.Context, date time.Time) ([]*model.Item, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetItemsInDate(ctx, date)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -257,12 +258,12 @@ func (r *queryResolver) ItemsInDate(ctx context.Context, date time.Time) ([]*mod
 func (r *queryResolver) ItemsInPeriod(ctx context.Context, input model.InputItemsInPeriod) (*model.ItemsInPeriod, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetItemsInPeriod(ctx, input)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -271,12 +272,12 @@ func (r *queryResolver) ItemsInPeriod(ctx context.Context, input model.InputItem
 func (r *queryResolver) Invite(ctx context.Context) (*model.Invite, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetInviteByUseID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -285,12 +286,12 @@ func (r *queryResolver) Invite(ctx context.Context) (*model.Invite, error) {
 func (r *queryResolver) InviteByCode(ctx context.Context, code string) (*model.User, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	result, err := g.GetInviteByCode(ctx, code)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -299,7 +300,7 @@ func (r *queryResolver) InviteByCode(ctx context.Context, code string) (*model.U
 func (r *queryResolver) RelationshipRequests(ctx context.Context, input model.InputRelationshipRequests) (*model.RelationshipRequests, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	userSkip := true
@@ -312,7 +313,7 @@ func (r *queryResolver) RelationshipRequests(ctx context.Context, input model.In
 
 	result, err := g.GetRelationshipRequests(ctx, input, userSkip)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil
@@ -321,7 +322,7 @@ func (r *queryResolver) RelationshipRequests(ctx context.Context, input model.In
 func (r *queryResolver) Relationships(ctx context.Context, input model.InputRelationships) (*model.Relationships, error) {
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	userSkip := true
@@ -334,7 +335,7 @@ func (r *queryResolver) Relationships(ctx context.Context, input model.InputRela
 
 	result, err := g.GetRelationships(ctx, input, userSkip)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return result, nil

--- a/graph/user.go
+++ b/graph/user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
 	"github.com/wheatandcat/memoir-backend/repository"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 // CreateUser ユーザー作成
@@ -17,7 +18,7 @@ func (g *Graph) CreateUser(ctx context.Context, input *model.NewUser) (*model.Us
 	}
 
 	if err := g.App.UserRepository.Create(ctx, g.FirestoreClient, u); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return u, nil
@@ -26,7 +27,7 @@ func (g *Graph) CreateUser(ctx context.Context, input *model.NewUser) (*model.Us
 // CreateAuthUser 認証済みユーザーを作成
 func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewAuthUser) (*model.AuthUser, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, fmt.Errorf("invalid authorization")
+		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
 	}
 
 	u := &repository.User{
@@ -41,7 +42,7 @@ func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewAuthUser) (*
 
 	exist, err := g.App.UserRepository.ExistByFirebaseUID(ctx, g.FirestoreClient, u.FirebaseUID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	if exist {
@@ -54,12 +55,12 @@ func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewAuthUser) (*
 			ID: input.ID,
 		}
 		if _, err = g.CreateUser(ctx, v); err != nil {
-			return nil, err
+			return nil, ce.CustomError(err)
 		}
 	}
 
 	if err = g.App.UserRepository.UpdateFirebaseUID(ctx, g.FirestoreClient, u); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return mu, nil
@@ -69,7 +70,7 @@ func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewAuthUser) (*
 func (g *Graph) GetUser(ctx context.Context) (*model.User, error) {
 	u, err := g.App.UserRepository.FindByUID(ctx, g.FirestoreClient, g.UserID)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return u, nil
@@ -82,7 +83,7 @@ func (g *Graph) ExistAuthUser(ctx context.Context) (*model.ExistAuthUser, error)
 
 	exist, err := g.App.UserRepository.ExistByFirebaseUID(ctx, g.FirestoreClient, g.Client.AuthToken.Get(ctx))
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	rau.Exist = exist
@@ -101,7 +102,7 @@ func (g *Graph) UpdateUser(ctx context.Context, input *model.UpdateUser) (*model
 
 	err := g.App.UserRepository.Update(ctx, g.FirestoreClient, u)
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return u, nil

--- a/repository/invite.go
+++ b/repository/invite.go
@@ -43,7 +43,7 @@ func (re *InviteRepository) FindByUserID(ctx context.Context, f *firestore.Clien
 	docs, err := matchItem.GetAll()
 
 	if err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	if len(docs) == 0 {

--- a/repository/item.go
+++ b/repository/item.go
@@ -75,7 +75,7 @@ func (re *ItemRepository) Update(ctx context.Context, f *firestore.Client, userI
 // Delete アイテムを削除する
 func (re *ItemRepository) Delete(ctx context.Context, f *firestore.Client, userID string, i *model.DeleteItem) error {
 	_, err := getItemCollection(f, userID).Doc(i.ID).Delete(ctx)
-	return err
+	return ce.CustomError(err)
 }
 
 // GetItem アイテムを取得する

--- a/usecase/custom_error/error.go
+++ b/usecase/custom_error/error.go
@@ -33,18 +33,26 @@ func GetCustomStackTrace(err error) errors.StackTrace {
 
 	if os.Getenv("APP_ENV") == "local" {
 		// エラー出力
+		fmt.Print("-----------------------\n")
 		fmt.Printf("■ error: %+v\n", err.Error())
 		if len(fs) > 3 {
 			fs = fs[:3]
 		}
 
 		fmt.Printf("■ stack trace: %+v\n", fs)
+		fmt.Print("-----------------------")
 	}
 
 	return fs
 }
 
 func CustomError(err error) error {
+	// 既にスタックトレースの設定がある場合は、そのままエラーを返す
+	_, ok := err.(interface{ StackTrace() errors.StackTrace })
+	if ok {
+		return err
+	}
+
 	e := errors.WithStack(err)
 	GetCustomStackTrace(e)
 
@@ -52,6 +60,12 @@ func CustomError(err error) error {
 }
 
 func CustomErrorWrap(err error, message string) error {
+	// 既にスタックトレースの設定がある場合は、そのままエラーを返す
+	_, ok := err.(interface{ StackTrace() errors.StackTrace })
+	if ok {
+		return err
+	}
+
 	e := errors.Wrap(err, message)
 	GetCustomStackTrace(e)
 


### PR DESCRIPTION
## 関連 issue

- fixes #75 

## 対応内容
 - 以下の修正のままだと全てのエラーを自作のエラーに置き換えると、Wrapした毎にスタックトレースが表示されて置き換えができなかったので、既にスタックトレースが設定されている場合は追加しないように修正

## 開発用メモ
無し

