### PR TITLE
APIにバリデーションを追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/99designs/gqlgen v0.13.0
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/go-chi/chi v3.3.2+incompatible
+	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
+github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=

--- a/graph/model/validate.go
+++ b/graph/model/validate.go
@@ -1,0 +1,33 @@
+package model
+
+import validation "github.com/go-ozzo/ozzo-validation"
+
+func (r UpdateUser) Validate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(
+			&r.DisplayName,
+			validation.Required.Error("名前の入力は必須です"),
+			validation.RuneLength(1, 30).Error("名前は最大30文字までです"),
+		),
+	)
+}
+
+func (r NewItem) Validate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(
+			&r.Title,
+			validation.Required.Error("タイトルの入力は必須です"),
+			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
+		),
+	)
+}
+
+func (r UpdateItem) Validate() error {
+	return validation.ValidateStruct(&r,
+		validation.Field(
+			&r.Title,
+			validation.Required.Error("タイトルの入力は必須です"),
+			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
+		),
+	)
+}

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -35,6 +35,10 @@ func (r *mutationResolver) CreateAuthUser(ctx context.Context, input model.NewAu
 }
 
 func (r *mutationResolver) UpdateUser(ctx context.Context, input model.UpdateUser) (*model.User, error) {
+	if err := input.Validate(); err != nil {
+		return nil, ce.CustomError(err)
+	}
+
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
 		return nil, ce.CustomError(err)
@@ -49,6 +53,10 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input model.UpdateUse
 }
 
 func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error) {
+	if err := input.Validate(); err != nil {
+		return nil, ce.CustomError(err)
+	}
+
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
 		return nil, ce.CustomError(err)
@@ -63,6 +71,10 @@ func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) 
 }
 
 func (r *mutationResolver) UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error) {
+	if err := input.Validate(); err != nil {
+		return nil, ce.CustomError(err)
+	}
+
 	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
 	if err != nil {
 		return nil, ce.CustomError(err)


### PR DESCRIPTION
## 関連 issue

- fixes #97

## 対応内容

<img width="1054" alt="スクリーンショット 2022-02-23 11 47 38" src="https://user-images.githubusercontent.com/19209314/155254884-21447370-d1e2-4025-b0eb-6fea999da254.png">


 - [ozzo-validation](https://github.com/go-ozzo/ozzo-validation)を使用してmutationにバリデーションを追加


## 開発用メモ
無し

