### PR TITLE
エラーにextensionsを設定する

### DIFF
--- a/.github/workflows/scenarigo.yml
+++ b/.github/workflows/scenarigo.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         node-version: '16'
     - name: setup gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: "latest"
     - name: setup firestore emulator

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ yarn graphql-markdown http://localhost:8080/query > schema.md
 
 ## GraphQLスキーマ更新
 
-```:zsh
+```zsh
 $ go run github.com/99designs/gqlgen generate
 ```
 
@@ -31,44 +31,44 @@ $ go run github.com/99designs/gqlgen generate
 
 ### 実行
 moqを生成
-```:zsh
+```zsh
 $ make moqgen
 ```
 
 テストを実行
-```:zsh
+```zsh
 $ go test -race ./...
 ```
 
 ### カバレッジ表示
 
 ### インストール
-```:zsh
+```zsh
 $ brew install k1LoW/tap/octocov
 ```
 
 ### 実行
-```:zsh
+```zsh
 $ go test ./... -coverprofile=coverage.out
 $ octocov
 ```
 
 ### 各ファイルカバレッジ確認
-```:zsh
+```zsh
 $ octocov ls-files
 ```
 
-```:zsh
+```zsh
 $ octocov view graph/invite.go
 ```
 
 ## E2Eテスト
 
-```:zsh
+```zsh
 $ FIRESTORE_EMULATOR_HOST=localhost:3600 air
 ```
 
-```:zsh
+```zsh
 $ cd e2e
 $ make create_loggin_yaml
 $ make local_scenarigo
@@ -76,13 +76,13 @@ $ make local_scenarigo
 
 ## 手動デプロイ
 
-```:zsh
+```zsh
 $ gcloud app deploy
 ```
 
 ## 本番デプロイ
 
-```:zsh
+```zsh
 $ git checkout main
 $ git pull --ff-only origin main
 $ git tag -a v1.0.0 -m 'リリース内容'
@@ -93,48 +93,48 @@ $ git push origin v1.0.0
 
 ### Firebase トークン
 
-```:zsh
+```zsh
 $ firebase login:ci
 ```
 ### レビュー環境
 
-```:zsh
+```zsh
 $ base64 -i serviceAccount.review.json | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i gcpServiceAccount.review.json | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i app.yaml | pbcopy
 ```
 
 ### E2E
 
-```:zsh
+```zsh
 $ base64 -i .env | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i envenb.go | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i e2e/.env | pbcopy
 ```
 
 ### 本番環境
 
-```:zsh
+```zsh
 $ base64 -i serviceAccount.production.json | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i gcpServiceAccount.production.json | pbcopy
 ```
 
-```:zsh
+```zsh
 $ base64 -i app.production.yaml | pbcopy
 ```
 

--- a/app.go
+++ b/app.go
@@ -94,7 +94,7 @@ func main() {
 			scope.SetTag("operationName", goc.OperationName)
 			scope.SetExtra("query", goc.RawQuery)
 			scope.SetExtra("variables", goc.Variables)
-			scope.SetExtra("Error Code", errorCode)
+			scope.SetExtra("errorCode", errorCode)
 
 			if err.Path.String() != "" {
 				sentry.AddBreadcrumb(&sentry.Breadcrumb{

--- a/graph/common_test.go
+++ b/graph/common_test.go
@@ -1,11 +1,14 @@
 package graph_test
 
 import (
+	"errors"
+
 	mock_authToken "github.com/wheatandcat/memoir-backend/client/authToken/mocks"
 	mock_task "github.com/wheatandcat/memoir-backend/client/task/mocks"
 	mock_timegen "github.com/wheatandcat/memoir-backend/client/timegen/mocks"
 	mock_uuidgen "github.com/wheatandcat/memoir-backend/client/uuidgen/mocks"
 	"github.com/wheatandcat/memoir-backend/graph"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 
 	moq_repository "github.com/wheatandcat/memoir-backend/repository/moq"
 )
@@ -35,4 +38,14 @@ func newGraph() graph.Graph {
 	}
 
 	return g
+}
+
+func getErrorCode(err error) string {
+	errorCode := ce.CodeDefault
+	var re ce.RequestError
+	if errors.As(err, &re) {
+		errorCode = re.Code
+	}
+
+	return errorCode
 }

--- a/graph/invite.go
+++ b/graph/invite.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
@@ -12,7 +11,7 @@ import (
 // CreateInvite 招待を作成する
 func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
@@ -21,7 +20,7 @@ func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 	}
 
 	if i.UserID == g.UserID {
-		return nil, ce.CustomError(fmt.Errorf("自身の招待コードです"))
+		return nil, ce.CustomError(ce.NewRequestError(ce.CodeMyInviteCode, "自身の招待コードです"))
 	}
 
 	uuid := g.Client.UUID.Get()
@@ -47,7 +46,7 @@ func (g *Graph) CreateInvite(ctx context.Context) (*model.Invite, error) {
 // UpdateInvite 招待を更新する
 func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
@@ -75,7 +74,7 @@ func (g *Graph) UpdateInvite(ctx context.Context) (*model.Invite, error) {
 // GetInviteByUseID ユーザーIDから招待を取得する
 func (g *Graph) GetInviteByUseID(ctx context.Context) (*model.Invite, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.FindByUserID(ctx, g.FirestoreClient, g.UserID)
@@ -89,7 +88,7 @@ func (g *Graph) GetInviteByUseID(ctx context.Context) (*model.Invite, error) {
 // GetInviteByCode コードから招待を取得する
 func (g *Graph) GetInviteByCode(ctx context.Context, code string) (*model.User, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	i, err := g.App.InviteRepository.Find(ctx, g.FirestoreClient, code)
@@ -98,7 +97,7 @@ func (g *Graph) GetInviteByCode(ctx context.Context, code string) (*model.User, 
 	}
 
 	if i.UserID == "" {
-		return nil, ce.CustomError(fmt.Errorf("招待コードが見つかりません"))
+		return nil, ce.CustomError(ce.NewNotFoundError("招待コードが見つかりません"))
 	}
 
 	u, err := g.App.UserRepository.FindByUID(ctx, g.FirestoreClient, i.UserID)

--- a/graph/invite_test.go
+++ b/graph/invite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wheatandcat/memoir-backend/client/uuidgen"
 	"github.com/wheatandcat/memoir-backend/graph"
 	"github.com/wheatandcat/memoir-backend/graph/model"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 	"gopkg.in/go-playground/assert.v1"
 
 	moq_repository "github.com/wheatandcat/memoir-backend/repository/moq"
@@ -25,49 +26,81 @@ func TestCreateInvite(t *testing.T) {
 
 	date := client.Time.ParseInLocation("2020-01-01T00:00:00")
 
-	invite := &model.Invite{
-		UserID:    "test",
-		Code:      "ABCDEFGH",
-		CreatedAt: date,
-		UpdatedAt: date,
+	type appParam struct {
+		Invite *model.Invite
 	}
 
-	g := newGraph()
+	appFunc := func(param appParam) graph.Graph {
+		g := newGraph()
 
-	inviteRepositoryMock := &moq_repository.InviteRepositoryInterfaceMock{
-		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Invite) {
-		},
-		FindByUserIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error) {
-			return &model.Invite{}, nil
-		},
-	}
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
-			return nil
-		},
-	}
+		inviteRepositoryMock := &moq_repository.InviteRepositoryInterfaceMock{
+			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Invite) {
+			},
+			FindByUserIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error) {
+				return param.Invite, nil
+			},
+		}
+		commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
+			CommitFunc: func(ctx context.Context, batch *firestore.WriteBatch) error {
+				return nil
+			},
+		}
 
-	g.App.InviteRepository = inviteRepositoryMock
-	g.App.CommonRepository = commonRepositoryMock
+		g.App.InviteRepository = inviteRepositoryMock
+		g.App.CommonRepository = commonRepositoryMock
+
+		return g
+	}
 
 	tests := []struct {
-		name   string
-		result *model.Invite
+		name    string
+		param   appParam
+		result  *model.Invite
+		errCode string
 	}{
 		{
-			name:   "招待コードを作成する",
-			result: invite,
+			name: "招待コードを作成する",
+			param: appParam{
+				Invite: &model.Invite{},
+			},
+			result: &model.Invite{
+				UserID:    "test",
+				Code:      "ABCDEFGH",
+				CreatedAt: date,
+				UpdatedAt: date,
+			},
+			errCode: "",
+		},
+		{
+			name: "エラー:自身の招待コードです",
+			param: appParam{
+				Invite: &model.Invite{
+					UserID: "test",
+				},
+			},
+			result:  nil,
+			errCode: ce.CodeMyInviteCode,
 		},
 	}
 
 	for _, td := range tests {
 		t.Run(td.name, func(t *testing.T) {
-			r, _ := g.CreateInvite(ctx)
-			diff := cmp.Diff(r, td.result)
-			if diff != "" {
-				t.Errorf("differs: (-got +want)\n%s", diff)
+			g := appFunc(td.param)
+			r, err := g.CreateInvite(ctx)
+			if td.result != nil {
+				diff := cmp.Diff(r, td.result)
+				if diff != "" {
+					t.Errorf("differs: (-got +want)\n%s", diff)
+				} else {
+					assert.Equal(t, diff, "")
+				}
 			} else {
-				assert.Equal(t, diff, "")
+				diff := cmp.Diff(getErrorCode(err), td.errCode)
+				if diff != "" {
+					t.Errorf("differs: (-got +want)\n%s", diff)
+				} else {
+					assert.Equal(t, diff, "")
+				}
 			}
 		})
 	}

--- a/graph/model/validate.go
+++ b/graph/model/validate.go
@@ -1,33 +1,42 @@
 package model
 
-import validation "github.com/go-ozzo/ozzo-validation"
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
+)
 
 func (r UpdateUser) Validate() error {
-	return validation.ValidateStruct(&r,
+	err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.DisplayName,
 			validation.Required.Error("名前の入力は必須です"),
 			validation.RuneLength(1, 30).Error("名前は最大30文字までです"),
 		),
 	)
+
+	return ce.NewValidationError(err.Error())
 }
 
 func (r NewItem) Validate() error {
-	return validation.ValidateStruct(&r,
+	err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.Title,
 			validation.Required.Error("タイトルの入力は必須です"),
 			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
 		),
 	)
+
+	return ce.NewValidationError(err.Error())
 }
 
 func (r UpdateItem) Validate() error {
-	return validation.ValidateStruct(&r,
+	err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.Title,
 			validation.Required.Error("タイトルの入力は必須です"),
 			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
 		),
 	)
+
+	return ce.NewValidationError(err.Error())
 }

--- a/graph/model/validate.go
+++ b/graph/model/validate.go
@@ -6,37 +6,43 @@ import (
 )
 
 func (r UpdateUser) Validate() error {
-	err := validation.ValidateStruct(&r,
+	if err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.DisplayName,
 			validation.Required.Error("名前の入力は必須です"),
 			validation.RuneLength(1, 30).Error("名前は最大30文字までです"),
 		),
-	)
+	); err != nil {
+		return ce.NewValidationError(err.Error())
+	}
 
-	return ce.NewValidationError(err.Error())
+	return nil
 }
 
 func (r NewItem) Validate() error {
-	err := validation.ValidateStruct(&r,
+	if err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.Title,
 			validation.Required.Error("タイトルの入力は必須です"),
 			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
 		),
-	)
+	); err != nil {
+		return ce.NewValidationError(err.Error())
+	}
 
-	return ce.NewValidationError(err.Error())
+	return nil
 }
 
 func (r UpdateItem) Validate() error {
-	err := validation.ValidateStruct(&r,
+	if err := validation.ValidateStruct(&r,
 		validation.Field(
 			&r.Title,
 			validation.Required.Error("タイトルの入力は必須です"),
 			validation.RuneLength(1, 100).Error("タイトルは最大100文字までです"),
 		),
-	)
+	); err != nil {
+		return ce.NewValidationError(err.Error())
+	}
 
-	return ce.NewValidationError(err.Error())
+	return nil
 }

--- a/graph/relationship.go
+++ b/graph/relationship.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
@@ -13,7 +12,7 @@ import (
 // DeleteRelationship 共有ユーザーを解除する
 func (g *Graph) DeleteRelationship(ctx context.Context, followedID string) (*model.Relationship, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	batch := g.FirestoreClient.Batch()

--- a/graph/user.go
+++ b/graph/user.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/wheatandcat/memoir-backend/graph/model"
 	"github.com/wheatandcat/memoir-backend/repository"
@@ -27,7 +26,7 @@ func (g *Graph) CreateUser(ctx context.Context, input *model.NewUser) (*model.Us
 // CreateAuthUser 認証済みユーザーを作成
 func (g *Graph) CreateAuthUser(ctx context.Context, input *model.NewAuthUser) (*model.AuthUser, error) {
 	if !g.Client.AuthToken.Valid(ctx) {
-		return nil, ce.CustomError(fmt.Errorf("invalid authorization"))
+		return nil, ce.CustomError(ce.NewInvalidAuthError("invalid authorization"))
 	}
 
 	u := &repository.User{

--- a/repository/user.go
+++ b/repository/user.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -116,7 +115,7 @@ func (re *UserRepository) FindByFirebaseUID(ctx context.Context, f *firestore.Cl
 	}
 
 	if len(docs) == 0 {
-		return nil, ce.CustomError(fmt.Errorf("not found user"))
+		return nil, ce.CustomError(ce.NewNotFoundError("ユーザーが存在しません"))
 	}
 
 	if err = docs[0].DataTo(&u); err != nil {

--- a/usecase/custom_error/code.go
+++ b/usecase/custom_error/code.go
@@ -1,0 +1,15 @@
+package custom_error
+
+const (
+	CodeDefault = "-1"
+	// バリデーションエラー
+	CodeValidation = "000001"
+	// 無効な認証
+	CodeInvalidAuthorization = "000002"
+	// Not Found
+	CodeNotFound = "000003"
+	// Already Exists
+	CodeAlreadyExists = "000004"
+	// 自身の招待コード
+	CodeMyInviteCode = "000005"
+)

--- a/usecase/custom_error/error.go
+++ b/usecase/custom_error/error.go
@@ -71,3 +71,32 @@ func CustomErrorWrap(err error, message string) error {
 
 	return e
 }
+
+type RequestError struct {
+	Code    string
+	Message string
+}
+
+func (re RequestError) Error() string {
+	return re.Message
+}
+
+func NewRequestError(code string, message string) error {
+	return RequestError{Code: code, Message: message}
+}
+
+func NewValidationError(message string) error {
+	return RequestError{Code: CodeValidation, Message: message}
+}
+
+func NewInvalidAuthError(message string) error {
+	return RequestError{Code: CodeInvalidAuthorization, Message: message}
+}
+
+func NewNotFoundError(message string) error {
+	return RequestError{Code: CodeNotFound, Message: message}
+}
+
+func NewAlreadyExists(message string) error {
+	return RequestError{Code: CodeAlreadyExists, Message: message}
+}


### PR DESCRIPTION
## 関連 issue

- fixes #98 

## 対応内容

<img width="480" alt="スクリーンショット 2022-02-23 23 54 59" src="https://user-images.githubusercontent.com/19209314/155352452-f619964b-5d84-4566-97db-fa55228c5f11.png">

 - GraphQLのエラーハンドリングでextensionsを追加
   - 参考: [GraphQLにおけるエラーハンドリングの仕方](https://techblog.zozo.com/entry/graphql_error_handling)
 - エラーコードを返すように修正

## 開発用メモ
無し

