### PR TITLE
アカウントを完全に削除する機能を実装

### DIFF
--- a/graph/common_test.go
+++ b/graph/common_test.go
@@ -2,6 +2,7 @@ package graph_test
 
 import (
 	"errors"
+	"testing"
 
 	mock_authToken "github.com/wheatandcat/memoir-backend/client/authToken/mocks"
 	mock_task "github.com/wheatandcat/memoir-backend/client/task/mocks"
@@ -9,6 +10,7 @@ import (
 	mock_uuidgen "github.com/wheatandcat/memoir-backend/client/uuidgen/mocks"
 	"github.com/wheatandcat/memoir-backend/graph"
 	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
+	"gopkg.in/go-playground/assert.v1"
 
 	moq_repository "github.com/wheatandcat/memoir-backend/repository/moq"
 	moq_usecase_auth "github.com/wheatandcat/memoir-backend/usecase/auth/moq"
@@ -51,4 +53,21 @@ func getErrorCode(err error) string {
 	}
 
 	return errorCode
+}
+
+func checkErrorCode(t *testing.T, err1 error, err2 error) {
+	code1 := ce.CodeDefault
+	code2 := ce.CodeDefault
+
+	var re1 ce.RequestError
+	if errors.As(err1, &re1) {
+		code1 = re1.Code
+	}
+	var re2 ce.RequestError
+	if errors.As(err2, &re2) {
+		code2 = re2.Code
+	}
+
+	assert.Equal(t, code1, code2)
+
 }

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -96,6 +96,7 @@ type ComplexityRoot struct {
 		CreateUser                func(childComplexity int, input model.NewUser) int
 		DeleteItem                func(childComplexity int, input model.DeleteItem) int
 		DeleteRelationship        func(childComplexity int, followedID string) int
+		DeleteUser                func(childComplexity int) int
 		NgRelationshipRequest     func(childComplexity int, followedID string) int
 		UpdateInvite              func(childComplexity int) int
 		UpdateItem                func(childComplexity int, input model.UpdateItem) int
@@ -180,6 +181,7 @@ type MutationResolver interface {
 	CreateUser(ctx context.Context, input model.NewUser) (*model.User, error)
 	CreateAuthUser(ctx context.Context, input model.NewAuthUser) (*model.AuthUser, error)
 	UpdateUser(ctx context.Context, input model.UpdateUser) (*model.User, error)
+	DeleteUser(ctx context.Context) (*model.User, error)
 	CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error)
 	UpdateItem(ctx context.Context, input model.UpdateItem) (*model.Item, error)
 	DeleteItem(ctx context.Context, input model.DeleteItem) (*model.Item, error)
@@ -489,6 +491,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteRelationship(childComplexity, args["followedID"].(string)), true
+
+	case "Mutation.deleteUser":
+		if e.complexity.Mutation.DeleteUser == nil {
+			break
+		}
+
+		return e.complexity.Mutation.DeleteUser(childComplexity), true
 
 	case "Mutation.ngRelationshipRequest":
 		if e.complexity.Mutation.NgRelationshipRequest == nil {
@@ -1206,6 +1215,8 @@ type Mutation {
   createAuthUser(input: NewAuthUser!): AuthUser!
   "ユーザーを更新する"
   updateUser(input: UpdateUser!): User!
+  "ユーザーを削除する"
+  deleteUser: User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
   "アイテムを更新する"
@@ -2539,6 +2550,41 @@ func (ec *executionContext) _Mutation_updateUser(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().UpdateUser(rctx, args["input"].(model.UpdateUser))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚖgithubᚗcomᚋwheatandcatᚋmemoirᚑbackendᚋgraphᚋmodelᚐUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_deleteUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteUser(rctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6338,6 +6384,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "updateUser":
 			out.Values[i] = ec._Mutation_updateUser(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteUser":
+			out.Values[i] = ec._Mutation_deleteUser(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -261,6 +261,8 @@ type Mutation {
   createAuthUser(input: NewAuthUser!): AuthUser!
   "ユーザーを更新する"
   updateUser(input: UpdateUser!): User!
+  "ユーザーを削除する"
+  deleteUser: User!
   "アイテムを作成する"
   createItem(input: NewItem!): Item!
   "アイテムを更新する"

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -52,6 +52,19 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, input model.UpdateUse
 	return result, nil
 }
 
+func (r *mutationResolver) DeleteUser(ctx context.Context) (*model.User, error) {
+	g, err := NewGraph(ctx, r.App, r.FirestoreClient)
+	if err != nil {
+		return nil, ce.CustomError(err)
+	}
+	result, err := g.DeleteUser(ctx)
+	if err != nil {
+		return nil, ce.CustomError(err)
+	}
+
+	return result, nil
+}
+
 func (r *mutationResolver) CreateItem(ctx context.Context, input model.NewItem) (*model.Item, error) {
 	if err := input.Validate(); err != nil {
 		return nil, ce.CustomError(err)

--- a/graph/user_test.go
+++ b/graph/user_test.go
@@ -16,6 +16,7 @@ import (
 
 	moq_repository "github.com/wheatandcat/memoir-backend/repository/moq"
 	moq_usecase_auth "github.com/wheatandcat/memoir-backend/usecase/auth/moq"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 )
 
 type contextKey struct {
@@ -24,6 +25,7 @@ type contextKey struct {
 
 type __ = context.Context
 type ___ = *firestore.Client
+type ____ = *firestore.WriteBatch
 
 func TestUpdateUser(t *testing.T) {
 	u := &auth.User{
@@ -262,6 +264,103 @@ func TestGetUser(t *testing.T) {
 				t.Errorf("differs: (-got +want)\n%s", diff)
 			} else {
 				assert.Equal(t, diff, "")
+			}
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	ctx := context.Background()
+
+	g := newGraph()
+
+	relationshipMock := &moq_repository.RelationshipInterfaceMock{
+		ExistByFollowedIDFunc: func(_ __, _ ___, _ string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	userRepositoryMock := &moq_repository.UserRepositoryInterfaceMock{
+		DeleteFunc: func(_ __, _ ___, _ ____, uid string) {
+			return
+		},
+	}
+
+	inviteRepositoryMock := &moq_repository.InviteRepositoryInterfaceMock{
+		DeleteByUserIDFunc: func(_ __, _ ___, _ ____, uid string) error {
+			return nil
+		},
+	}
+
+	relationshipRequestMock := &moq_repository.RelationshipRequestInterfaceMock{
+		DeleteByFollowedIDFunc: func(_ __, _ ___, _ ____, uid string) error {
+			return nil
+		},
+		DeleteByFollowerIDFunc: func(_ __, _ ___, _ ____, uid string) error {
+			return nil
+		},
+	}
+
+	authMock := &moq_usecase_auth.UseCaseMock{
+		DeleteAuthUserFunc: func(_ __, _ ___, uid string) error {
+			return nil
+		},
+	}
+
+	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
+		CommitFunc: func(_ __, _ ____) error {
+			return nil
+		},
+	}
+
+	g.App.RelationshipRepository = relationshipMock
+	g.App.UserRepository = userRepositoryMock
+	g.App.InviteRepository = inviteRepositoryMock
+	g.App.RelationshipRequestRepository = relationshipRequestMock
+	g.App.AuthUseCase = authMock
+	g.App.CommonRepository = commonRepositoryMock
+
+	tests := []struct {
+		name   string
+		mock   func()
+		result *model.User
+		err    error
+	}{
+		{
+			name: "ユーザーを削除する",
+			mock: func() {},
+			result: &model.User{
+				ID: "test",
+			},
+			err: nil,
+		},
+		{
+			name: "共有メンバーが存在する",
+			mock: func() {
+				relationshipMock = &moq_repository.RelationshipInterfaceMock{
+					ExistByFollowedIDFunc: func(_ __, _ ___, _ string) (bool, error) {
+						return true, nil
+					},
+				}
+				g.App.RelationshipRepository = relationshipMock
+			},
+			result: nil,
+			err:    ce.NewRequestError(ce.HasRelationshipByDeleteUser, "共有メンバーが設定されています"),
+		},
+	}
+
+	for _, td := range tests {
+		t.Run(td.name, func(t *testing.T) {
+			td.mock()
+			r, err := g.DeleteUser(ctx)
+			diff := cmp.Diff(r, td.result)
+			if diff != "" {
+				t.Errorf("differs: (-got +want)\n%s", diff)
+			} else {
+				assert.Equal(t, diff, "")
+			}
+			if td.err != nil {
+				checkErrorCode(t, err, td.err)
 			}
 		})
 	}

--- a/repository/moq/invite.go
+++ b/repository/moq/invite.go
@@ -27,6 +27,9 @@ var _ repository.InviteRepositoryInterface = &InviteRepositoryInterfaceMock{}
 // 			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, code string)  {
 // 				panic("mock out the Delete method")
 // 			},
+// 			DeleteByUserIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+// 				panic("mock out the DeleteByUserID method")
+// 			},
 // 			FindFunc: func(ctx context.Context, f *firestore.Client, code string) (*model.Invite, error) {
 // 				panic("mock out the Find method")
 // 			},
@@ -45,6 +48,9 @@ type InviteRepositoryInterfaceMock struct {
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, code string)
+
+	// DeleteByUserIDFunc mocks the DeleteByUserID method.
+	DeleteByUserIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error
 
 	// FindFunc mocks the Find method.
 	FindFunc func(ctx context.Context, f *firestore.Client, code string) (*model.Invite, error)
@@ -76,6 +82,17 @@ type InviteRepositoryInterfaceMock struct {
 			// Code is the code argument value.
 			Code string
 		}
+		// DeleteByUserID holds details about calls to the DeleteByUserID method.
+		DeleteByUserID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// UserID is the userID argument value.
+			UserID string
+		}
 		// Find holds details about calls to the Find method.
 		Find []struct {
 			// Ctx is the ctx argument value.
@@ -95,10 +112,11 @@ type InviteRepositoryInterfaceMock struct {
 			UserID string
 		}
 	}
-	lockCreate       sync.RWMutex
-	lockDelete       sync.RWMutex
-	lockFind         sync.RWMutex
-	lockFindByUserID sync.RWMutex
+	lockCreate         sync.RWMutex
+	lockDelete         sync.RWMutex
+	lockDeleteByUserID sync.RWMutex
+	lockFind           sync.RWMutex
+	lockFindByUserID   sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -184,6 +202,49 @@ func (mock *InviteRepositoryInterfaceMock) DeleteCalls() []struct {
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete
 	mock.lockDelete.RUnlock()
+	return calls
+}
+
+// DeleteByUserID calls DeleteByUserIDFunc.
+func (mock *InviteRepositoryInterfaceMock) DeleteByUserID(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+	if mock.DeleteByUserIDFunc == nil {
+		panic("InviteRepositoryInterfaceMock.DeleteByUserIDFunc: method is nil but InviteRepositoryInterface.DeleteByUserID was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}{
+		Ctx:    ctx,
+		F:      f,
+		Batch:  batch,
+		UserID: userID,
+	}
+	mock.lockDeleteByUserID.Lock()
+	mock.calls.DeleteByUserID = append(mock.calls.DeleteByUserID, callInfo)
+	mock.lockDeleteByUserID.Unlock()
+	return mock.DeleteByUserIDFunc(ctx, f, batch, userID)
+}
+
+// DeleteByUserIDCalls gets all the calls that were made to DeleteByUserID.
+// Check the length with:
+//     len(mockedInviteRepositoryInterface.DeleteByUserIDCalls())
+func (mock *InviteRepositoryInterfaceMock) DeleteByUserIDCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	Batch  *firestore.WriteBatch
+	UserID string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}
+	mock.lockDeleteByUserID.RLock()
+	calls = mock.calls.DeleteByUserID
+	mock.lockDeleteByUserID.RUnlock()
 	return calls
 }
 

--- a/repository/moq/relationship.go
+++ b/repository/moq/relationship.go
@@ -27,6 +27,9 @@ var _ repository.RelationshipInterface = &RelationshipInterfaceMock{}
 // 			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)  {
 // 				panic("mock out the Delete method")
 // 			},
+// 			ExistByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (bool, error) {
+// 				panic("mock out the ExistByFollowedID method")
+// 			},
 // 			FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipCursor) ([]*model.Relationship, error) {
 // 				panic("mock out the FindByFollowedID method")
 // 			},
@@ -42,6 +45,9 @@ type RelationshipInterfaceMock struct {
 
 	// DeleteFunc mocks the Delete method.
 	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, i *model.Relationship)
+
+	// ExistByFollowedIDFunc mocks the ExistByFollowedID method.
+	ExistByFollowedIDFunc func(ctx context.Context, f *firestore.Client, userID string) (bool, error)
 
 	// FindByFollowedIDFunc mocks the FindByFollowedID method.
 	FindByFollowedIDFunc func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipCursor) ([]*model.Relationship, error)
@@ -70,6 +76,15 @@ type RelationshipInterfaceMock struct {
 			// I is the i argument value.
 			I *model.Relationship
 		}
+		// ExistByFollowedID holds details about calls to the ExistByFollowedID method.
+		ExistByFollowedID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// UserID is the userID argument value.
+			UserID string
+		}
 		// FindByFollowedID holds details about calls to the FindByFollowedID method.
 		FindByFollowedID []struct {
 			// Ctx is the ctx argument value.
@@ -84,9 +99,10 @@ type RelationshipInterfaceMock struct {
 			Cursor repository.RelationshipCursor
 		}
 	}
-	lockCreate           sync.RWMutex
-	lockDelete           sync.RWMutex
-	lockFindByFollowedID sync.RWMutex
+	lockCreate            sync.RWMutex
+	lockDelete            sync.RWMutex
+	lockExistByFollowedID sync.RWMutex
+	lockFindByFollowedID  sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -172,6 +188,45 @@ func (mock *RelationshipInterfaceMock) DeleteCalls() []struct {
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete
 	mock.lockDelete.RUnlock()
+	return calls
+}
+
+// ExistByFollowedID calls ExistByFollowedIDFunc.
+func (mock *RelationshipInterfaceMock) ExistByFollowedID(ctx context.Context, f *firestore.Client, userID string) (bool, error) {
+	if mock.ExistByFollowedIDFunc == nil {
+		panic("RelationshipInterfaceMock.ExistByFollowedIDFunc: method is nil but RelationshipInterface.ExistByFollowedID was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+	}{
+		Ctx:    ctx,
+		F:      f,
+		UserID: userID,
+	}
+	mock.lockExistByFollowedID.Lock()
+	mock.calls.ExistByFollowedID = append(mock.calls.ExistByFollowedID, callInfo)
+	mock.lockExistByFollowedID.Unlock()
+	return mock.ExistByFollowedIDFunc(ctx, f, userID)
+}
+
+// ExistByFollowedIDCalls gets all the calls that were made to ExistByFollowedID.
+// Check the length with:
+//     len(mockedRelationshipInterface.ExistByFollowedIDCalls())
+func (mock *RelationshipInterfaceMock) ExistByFollowedIDCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	UserID string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		UserID string
+	}
+	mock.lockExistByFollowedID.RLock()
+	calls = mock.calls.ExistByFollowedID
+	mock.lockExistByFollowedID.RUnlock()
 	return calls
 }
 

--- a/repository/moq/relationship_request.go
+++ b/repository/moq/relationship_request.go
@@ -24,6 +24,12 @@ var _ repository.RelationshipRequestInterface = &RelationshipRequestInterfaceMoc
 // 			CreateFunc: func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) error {
 // 				panic("mock out the Create method")
 // 			},
+// 			DeleteByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+// 				panic("mock out the DeleteByFollowedID method")
+// 			},
+// 			DeleteByFollowerIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+// 				panic("mock out the DeleteByFollowerID method")
+// 			},
 // 			FindFunc: func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error) {
 // 				panic("mock out the Find method")
 // 			},
@@ -42,6 +48,12 @@ var _ repository.RelationshipRequestInterface = &RelationshipRequestInterfaceMoc
 type RelationshipRequestInterfaceMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) error
+
+	// DeleteByFollowedIDFunc mocks the DeleteByFollowedID method.
+	DeleteByFollowedIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error
+
+	// DeleteByFollowerIDFunc mocks the DeleteByFollowerID method.
+	DeleteByFollowerIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error
 
 	// FindFunc mocks the Find method.
 	FindFunc func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error)
@@ -62,6 +74,28 @@ type RelationshipRequestInterfaceMock struct {
 			F *firestore.Client
 			// I is the i argument value.
 			I *model.RelationshipRequest
+		}
+		// DeleteByFollowedID holds details about calls to the DeleteByFollowedID method.
+		DeleteByFollowedID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// UserID is the userID argument value.
+			UserID string
+		}
+		// DeleteByFollowerID holds details about calls to the DeleteByFollowerID method.
+		DeleteByFollowerID []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// UserID is the userID argument value.
+			UserID string
 		}
 		// Find holds details about calls to the Find method.
 		Find []struct {
@@ -97,10 +131,12 @@ type RelationshipRequestInterfaceMock struct {
 			I *model.RelationshipRequest
 		}
 	}
-	lockCreate           sync.RWMutex
-	lockFind             sync.RWMutex
-	lockFindByFollowedID sync.RWMutex
-	lockUpdate           sync.RWMutex
+	lockCreate             sync.RWMutex
+	lockDeleteByFollowedID sync.RWMutex
+	lockDeleteByFollowerID sync.RWMutex
+	lockFind               sync.RWMutex
+	lockFindByFollowedID   sync.RWMutex
+	lockUpdate             sync.RWMutex
 }
 
 // Create calls CreateFunc.
@@ -139,6 +175,92 @@ func (mock *RelationshipRequestInterfaceMock) CreateCalls() []struct {
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create
 	mock.lockCreate.RUnlock()
+	return calls
+}
+
+// DeleteByFollowedID calls DeleteByFollowedIDFunc.
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedID(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+	if mock.DeleteByFollowedIDFunc == nil {
+		panic("RelationshipRequestInterfaceMock.DeleteByFollowedIDFunc: method is nil but RelationshipRequestInterface.DeleteByFollowedID was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}{
+		Ctx:    ctx,
+		F:      f,
+		Batch:  batch,
+		UserID: userID,
+	}
+	mock.lockDeleteByFollowedID.Lock()
+	mock.calls.DeleteByFollowedID = append(mock.calls.DeleteByFollowedID, callInfo)
+	mock.lockDeleteByFollowedID.Unlock()
+	return mock.DeleteByFollowedIDFunc(ctx, f, batch, userID)
+}
+
+// DeleteByFollowedIDCalls gets all the calls that were made to DeleteByFollowedID.
+// Check the length with:
+//     len(mockedRelationshipRequestInterface.DeleteByFollowedIDCalls())
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedIDCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	Batch  *firestore.WriteBatch
+	UserID string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}
+	mock.lockDeleteByFollowedID.RLock()
+	calls = mock.calls.DeleteByFollowedID
+	mock.lockDeleteByFollowedID.RUnlock()
+	return calls
+}
+
+// DeleteByFollowerID calls DeleteByFollowerIDFunc.
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerID(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, userID string) error {
+	if mock.DeleteByFollowerIDFunc == nil {
+		panic("RelationshipRequestInterfaceMock.DeleteByFollowerIDFunc: method is nil but RelationshipRequestInterface.DeleteByFollowerID was just called")
+	}
+	callInfo := struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}{
+		Ctx:    ctx,
+		F:      f,
+		Batch:  batch,
+		UserID: userID,
+	}
+	mock.lockDeleteByFollowerID.Lock()
+	mock.calls.DeleteByFollowerID = append(mock.calls.DeleteByFollowerID, callInfo)
+	mock.lockDeleteByFollowerID.Unlock()
+	return mock.DeleteByFollowerIDFunc(ctx, f, batch, userID)
+}
+
+// DeleteByFollowerIDCalls gets all the calls that were made to DeleteByFollowerID.
+// Check the length with:
+//     len(mockedRelationshipRequestInterface.DeleteByFollowerIDCalls())
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerIDCalls() []struct {
+	Ctx    context.Context
+	F      *firestore.Client
+	Batch  *firestore.WriteBatch
+	UserID string
+} {
+	var calls []struct {
+		Ctx    context.Context
+		F      *firestore.Client
+		Batch  *firestore.WriteBatch
+		UserID string
+	}
+	mock.lockDeleteByFollowerID.RLock()
+	calls = mock.calls.DeleteByFollowerID
+	mock.lockDeleteByFollowerID.RUnlock()
 	return calls
 }
 

--- a/repository/moq/user.go
+++ b/repository/moq/user.go
@@ -24,6 +24,9 @@ var _ repository.UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 // 			CreateFunc: func(ctx context.Context, f *firestore.Client, u *model.User) error {
 // 				panic("mock out the Create method")
 // 			},
+// 			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, uid string)  {
+// 				panic("mock out the Delete method")
+// 			},
 // 			ExistByFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, fUID string) (bool, error) {
 // 				panic("mock out the ExistByFirebaseUID method")
 // 			},
@@ -54,6 +57,9 @@ var _ repository.UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 type UserRepositoryInterfaceMock struct {
 	// CreateFunc mocks the Create method.
 	CreateFunc func(ctx context.Context, f *firestore.Client, u *model.User) error
+
+	// DeleteFunc mocks the Delete method.
+	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, uid string)
 
 	// ExistByFirebaseUIDFunc mocks the ExistByFirebaseUID method.
 	ExistByFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, fUID string) (bool, error)
@@ -86,6 +92,17 @@ type UserRepositoryInterfaceMock struct {
 			F *firestore.Client
 			// U is the u argument value.
 			U *model.User
+		}
+		// Delete holds details about calls to the Delete method.
+		Delete []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// F is the f argument value.
+			F *firestore.Client
+			// Batch is the batch argument value.
+			Batch *firestore.WriteBatch
+			// UID is the uid argument value.
+			UID string
 		}
 		// ExistByFirebaseUID holds details about calls to the ExistByFirebaseUID method.
 		ExistByFirebaseUID []struct {
@@ -152,6 +169,7 @@ type UserRepositoryInterfaceMock struct {
 		}
 	}
 	lockCreate                sync.RWMutex
+	lockDelete                sync.RWMutex
 	lockExistByFirebaseUID    sync.RWMutex
 	lockFindByFirebaseUID     sync.RWMutex
 	lockFindByUID             sync.RWMutex
@@ -197,6 +215,49 @@ func (mock *UserRepositoryInterfaceMock) CreateCalls() []struct {
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create
 	mock.lockCreate.RUnlock()
+	return calls
+}
+
+// Delete calls DeleteFunc.
+func (mock *UserRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, uid string) {
+	if mock.DeleteFunc == nil {
+		panic("UserRepositoryInterfaceMock.DeleteFunc: method is nil but UserRepositoryInterface.Delete was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		UID   string
+	}{
+		Ctx:   ctx,
+		F:     f,
+		Batch: batch,
+		UID:   uid,
+	}
+	mock.lockDelete.Lock()
+	mock.calls.Delete = append(mock.calls.Delete, callInfo)
+	mock.lockDelete.Unlock()
+	mock.DeleteFunc(ctx, f, batch, uid)
+}
+
+// DeleteCalls gets all the calls that were made to Delete.
+// Check the length with:
+//     len(mockedUserRepositoryInterface.DeleteCalls())
+func (mock *UserRepositoryInterfaceMock) DeleteCalls() []struct {
+	Ctx   context.Context
+	F     *firestore.Client
+	Batch *firestore.WriteBatch
+	UID   string
+} {
+	var calls []struct {
+		Ctx   context.Context
+		F     *firestore.Client
+		Batch *firestore.WriteBatch
+		UID   string
+	}
+	mock.lockDelete.RLock()
+	calls = mock.calls.Delete
+	mock.lockDelete.RUnlock()
 	return calls
 }
 

--- a/repository/user.go
+++ b/repository/user.go
@@ -17,6 +17,7 @@ type UserRepositoryInterface interface {
 	Create(ctx context.Context, f *firestore.Client, u *model.User) error
 	Update(ctx context.Context, f *firestore.Client, u *model.User) error
 	UpdateFirebaseUID(ctx context.Context, f *firestore.Client, user *User) error
+	Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, uid string)
 	FindByUID(ctx context.Context, f *firestore.Client, uid string) (*model.User, error)
 	FindDatabaseDataByUID(ctx context.Context, f *firestore.Client, uid string) (*User, error)
 	FindByFirebaseUID(ctx context.Context, f *firestore.Client, fUID string) (*model.User, error)
@@ -61,6 +62,12 @@ func (re *UserRepository) Update(ctx context.Context, f *firestore.Client, u *mo
 	_, err := f.Collection("users").Doc(u.ID).Update(ctx, fu)
 
 	return ce.CustomError(err)
+}
+
+// Delete ユーザーを削除する
+func (re *UserRepository) Delete(ctx context.Context, f *firestore.Client, batch *firestore.WriteBatch, uid string) {
+	ref := f.Collection("users").Doc(uid)
+	batch.Delete(ref)
 }
 
 // UpdateFirebaseUID ユーザーFirebaseUIを更新する

--- a/schema.md
+++ b/schema.md
@@ -8,6 +8,8 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
   * [Query](#query)
   * [Mutation](#mutation)
   * [Objects](#objects)
+    * [AuthUser](#authuser)
+    * [ExistAuthUser](#existauthuser)
     * [Invite](#invite)
     * [Item](#item)
     * [ItemsInPeriod](#itemsinperiod)
@@ -26,6 +28,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
     * [InputItemsInPeriod](#inputitemsinperiod)
     * [InputRelationshipRequests](#inputrelationshiprequests)
     * [InputRelationships](#inputrelationships)
+    * [NewAuthUser](#newauthuser)
     * [NewItem](#newitem)
     * [NewPushToken](#newpushtoken)
     * [NewRelationshipRequest](#newrelationshiprequest)
@@ -59,6 +62,15 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td>
 
 ユーザーを取得する
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>existAuthUser</strong></td>
+<td valign="top"><a href="#existauthuser">ExistAuthUser</a>!</td>
+<td>
+
+認証ユーザーが存在するか判定する
 
 </td>
 </tr>
@@ -199,7 +211,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>createAuthUser</strong></td>
-<td valign="top"><a href="#user">User</a>!</td>
+<td valign="top"><a href="#authuser">AuthUser</a>!</td>
 <td>
 
 認証ユーザーを作成する
@@ -208,7 +220,7 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">input</td>
-<td valign="top"><a href="#newuser">NewUser</a>!</td>
+<td valign="top"><a href="#newauthuser">NewAuthUser</a>!</td>
 <td></td>
 </tr>
 <tr>
@@ -224,6 +236,15 @@ $ /Users/iinoyouhei/go/src/github.com/wheatandcat/memoir-backend/node_modules/.b
 <td colspan="2" align="right" valign="top">input</td>
 <td valign="top"><a href="#updateuser">UpdateUser</a>!</td>
 <td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deleteUser</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td>
+
+ユーザーを削除する
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>createItem</strong></td>
@@ -359,6 +380,95 @@ Push通知のトークンを作成する
 </table>
 
 ## Objects
+
+### AuthUser
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>displayName</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+表示名
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>image</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+画像URL
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>new</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+新規作成
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createdAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+作成日時
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedAt</strong></td>
+<td valign="top"><a href="#time">Time</a>!</td>
+<td>
+
+更新日時
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### ExistAuthUser
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>exist</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
 
 ### Invite
 
@@ -1000,12 +1110,56 @@ ID
 <tr>
 <td colspan="2" valign="top"><strong>startDate</strong></td>
 <td valign="top"><a href="#time">Time</a>!</td>
-<td></td>
+<td>
+
+開始日
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endDate</strong></td>
 <td valign="top"><a href="#time">Time</a>!</td>
-<td></td>
+<td>
+
+終了日
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userIDList</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td>
+
+ユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>categoryID</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td>
+
+カテゴリーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>like</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Good
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>dislike</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Bad
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -1054,6 +1208,38 @@ ID
 <td colspan="2" valign="top"><strong>first</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
 <td></td>
+</tr>
+</tbody>
+</table>
+
+### NewAuthUser
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ユーザーID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isNewUser</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td>
+
+true: ユーザー作成を行う
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -1303,4 +1489,4 @@ The `String`scalar type represents textual data, represented as UTF-8 character 
 
 ### Time
 
-Done in 2.56s.
+Done in 0.19s.

--- a/usecase/auth/delete.go
+++ b/usecase/auth/delete.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	"github.com/wheatandcat/memoir-backend/repository"
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
+)
+
+// ユーザーを削除
+func (uci *useCaseImpl) DeleteAuthUser(ctx context.Context, f *firestore.Client, uid string) error {
+	app, err := repository.FirebaseApp(ctx)
+	if err != nil {
+		return ce.CustomError(err)
+	}
+	client, err := app.Auth(ctx)
+	if err != nil {
+		return ce.CustomError(err)
+	}
+	if err := client.DeleteUser(ctx, uid); err != nil {
+		return ce.CustomError(err)
+	}
+
+	return nil
+}

--- a/usecase/auth/usecase.go
+++ b/usecase/auth/usecase.go
@@ -12,6 +12,7 @@ import (
 
 type UseCase interface {
 	CreateAuthUser(ctx context.Context, f *firestore.Client, input *model.NewAuthUser, u *repository.User, mu *model.AuthUser) (string, error)
+	DeleteAuthUser(ctx context.Context, f *firestore.Client, uid string) error
 }
 
 type useCaseImpl struct {

--- a/usecase/custom_error/code.go
+++ b/usecase/custom_error/code.go
@@ -12,4 +12,6 @@ const (
 	CodeAlreadyExists = "000004"
 	// 自身の招待コード
 	CodeMyInviteCode = "000005"
+	// ユーザー削除時に共有メンバーが存在する
+	HasRelationshipByDeleteUser = "000006"
 )


### PR DESCRIPTION
## 関連 issue

- fixes #104 

## 対応内容

以下のGraphQLを作成
 - Mutation: deleteUser
   - 以下を削除 
     - ユーザーに紐づくFirestoreの情報を削除
     - Firebase Authの情報を削除
     - Firebase Storageにアップロードしている画像を削除 
## 開発用メモ
無し

