### PR TITLE
静的解析でCustomErrorでラップされていないで return を修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,10 @@ $ base64 -i serviceAccount.production.json | pbcopy
 ```zsh
 $ base64 -i gcpServiceAccount.production.json | pbcopy
 ```
+
+## 静的解析
+
+```zsh
+$ go install github.com/wheatandcat/memoir-static-analytics/checkcustomerror/cmd/checkcustomerror@v0.0.7
+$ go vet -vettool=$(which checkcustomerror) ./...
+```

--- a/repository/item.go
+++ b/repository/item.go
@@ -85,7 +85,7 @@ func (re *ItemRepository) GetItem(ctx context.Context, f *firestore.Client, user
 	}
 
 	if err = ds.DataTo(&i); err != nil {
-		return nil, err
+		return nil, ce.CustomError(err)
 	}
 
 	return i, nil

--- a/repository/user.go
+++ b/repository/user.go
@@ -71,7 +71,7 @@ func (re *UserRepository) Delete(ctx context.Context, f *firestore.Client, batch
 	matchPushToken := ref.Collection("pushToken").Documents(ctx)
 	docPushTokens, err := matchPushToken.GetAll()
 	if err != nil {
-		return err
+		return ce.CustomError(err)
 	}
 	for _, doc := range docPushTokens {
 		batch.Delete(doc.Ref)
@@ -80,7 +80,7 @@ func (re *UserRepository) Delete(ctx context.Context, f *firestore.Client, batch
 	matchItems := ref.Collection("items").Documents(ctx)
 	docItems, err := matchItems.GetAll()
 	if err != nil {
-		return err
+		return ce.CustomError(err)
 	}
 	for _, doc := range docItems {
 		batch.Delete(doc.Ref)

--- a/usecase/app_trace/middleware.go
+++ b/usecase/app_trace/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 
+	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -123,5 +124,5 @@ func (t graphqlTracer) InterceptField(
 		span.SetAttributes(attribute.Key("error.message").String(err.Message))
 	}
 
-	return res, err
+	return res, ce.CustomError(err)
 }

--- a/usecase/auth/create.go
+++ b/usecase/auth/create.go
@@ -23,15 +23,15 @@ func (uci *useCaseImpl) CreateAuthUser(ctx context.Context, f *firestore.Client,
 
 	app, err := repository.FirebaseApp(ctx)
 	if err != nil {
-		return displayName, err
+		return displayName, ce.CustomError(err)
 	}
 	client, err := app.Auth(ctx)
 	if err != nil {
-		return displayName, err
+		return displayName, ce.CustomError(err)
 	}
 	user, err := client.GetUser(ctx, u.FirebaseUID)
 	if err != nil {
-		return displayName, err
+		return displayName, ce.CustomError(err)
 	}
 
 	arr1 := strings.Split(user.UserInfo.Email, "@")
@@ -93,5 +93,5 @@ func (uci *useCaseImpl) CreateAuthUser(ctx context.Context, f *firestore.Client,
 		return nil
 	})
 
-	return displayName, err
+	return displayName, ce.CustomError(err)
 }

--- a/usecase/custom_error/error.go
+++ b/usecase/custom_error/error.go
@@ -50,26 +50,26 @@ func CustomError(err error) error {
 	// 既にスタックトレースの設定がある場合は、そのままエラーを返す
 	_, ok := err.(interface{ StackTrace() errors.StackTrace })
 	if ok {
-		return err
+		return err // nocheck:checkcustomerror
 	}
 
 	e := errors.WithStack(err)
 	GetCustomStackTrace(e)
 
-	return e
+	return e // nocheck:checkcustomerror
 }
 
 func CustomErrorWrap(err error, message string) error {
 	// 既にスタックトレースの設定がある場合は、そのままエラーを返す
 	_, ok := err.(interface{ StackTrace() errors.StackTrace })
 	if ok {
-		return err
+		return err // nocheck:checkcustomerror
 	}
 
 	e := errors.Wrap(err, message)
 	GetCustomStackTrace(e)
 
-	return e
+	return e // nocheck:checkcustomerror
 }
 
 type RequestError struct {


### PR DESCRIPTION
## 関連 issue

- fixes #146 

## 対応内容


 - 以下で作成した静的解析ツールを導入して修正
    - [checkcustomerror](https://github.com/wheatandcat/memoir-static-analytics/tree/main/checkcustomerror) 
 - CustomErrorでラップせずにエラーをreturnしている箇所を検出している箇所を修正

## 開発用メモ
無し

