### PR TITLE
Firestore.BulkWriterからRunTransactionに移行

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ e2e/login.yaml
 e2e/serviceAccount.json
 ui-debug.log
 firestore-debug.log
+firebase-debug.log
 envenb.go
 service-review.yaml
 build-config-review.yaml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ $ make install
 $ air
 ```
 
+### ローカル環境で Firesbase エミュレータ起動して使用する
+
+```
+$ npx firebase --config ./e2e/simulator/firebase.json emulators:start
+```
+
 ## GraphQL スキーマドキュメント
 
 ```
@@ -44,7 +50,7 @@ $ make moqgen
 $ go test ./...
 ```
 
-### カバレッジ表示
+## カバレッジ表示
 
 ### インストール
 

--- a/e2e/delete_user.yaml
+++ b/e2e/delete_user.yaml
@@ -20,3 +20,5 @@ steps:
               id
             }
           }
+    expect:
+      code: 200

--- a/e2e/delete_user.yaml
+++ b/e2e/delete_user.yaml
@@ -4,26 +4,7 @@ steps:
     include: "./login.yaml"
     bind:
       vars:
-        userToken: "{{vars.userToken1}}"
-  - title: 共有メンバーを解除する
-    protocol: http
-    request:
-      method: POST
-      url: "http://{{env.HOST}}/query"
-      header:
-        Authorization: "Bearer {{vars.userToken}}"
-        Content-Type: application/json
-      body:
-        query: |-
-          mutation DeleteRelationship($followedID: String!) {
-            deleteRelationship(followedID: $followedID) {
-              id
-              followerId
-              followedId
-            }
-          }
-        variables:
-          followedID: "test_id2"
+        userToken: "{{vars.userToken3}}"
   - title: ユーザーを退会する
     protocol: http
     request:

--- a/e2e/invite.yaml
+++ b/e2e/invite.yaml
@@ -191,3 +191,22 @@ steps:
               - node:
                   followerId: "test_id2"
                   followedId: "test_id1"
+  - title: 共有メンバーを解除する
+    protocol: http
+    request:
+      method: POST
+      url: "http://{{env.HOST}}/query"
+      header:
+        Authorization: "Bearer {{vars.userToken1}}"
+        Content-Type: application/json
+      body:
+        query: |-
+          mutation DeleteRelationship($followedID: String!) {
+            deleteRelationship(followedID: $followedID) {
+              id
+              followerId
+              followedId
+            }
+          }
+        variables:
+          followedID: "test_id2"

--- a/e2e/invite.yaml
+++ b/e2e/invite.yaml
@@ -24,6 +24,8 @@ steps:
               code
             }
           }
+    expect:
+      code: 200
   - title: 招待をリクエスト
     bind:
       vars:
@@ -87,6 +89,7 @@ steps:
             first: 1
           skip: true
     expect:
+      code: 200
       body:
         data:
           relationshipRequests:
@@ -113,6 +116,8 @@ steps:
           }
         variables:
           followedID: "{{vars.followerId}}"
+    expect:
+      code: 200
   - title: 共有ユーザーを取得①
     protocol: http
     request:
@@ -184,6 +189,7 @@ steps:
             first: 1
           skip: true
     expect:
+      code: 200
       body:
         data:
           relationships:
@@ -210,3 +216,5 @@ steps:
           }
         variables:
           followedID: "test_id2"
+    expect:
+      code: 200

--- a/e2e/item.yaml
+++ b/e2e/item.yaml
@@ -37,7 +37,8 @@ steps:
             date: 2021-01-01T00:00:00+09:00
             like: true
             dislike: false
-
+    expect:
+      code: 200
   - title: アイテムを取得する
     protocol: http
     request:
@@ -61,6 +62,7 @@ steps:
         variables:
           id: "{{vars.itemID}}"
     expect:
+      code: 200
       body:
         data:
           item:

--- a/e2e/scenarigo.yaml
+++ b/e2e/scenarigo.yaml
@@ -5,4 +5,5 @@ scenarios:
   - user2.yaml
   - item.yaml
   - invite.yaml
+  - user3.yaml
   - delete_user.yaml

--- a/e2e/script/main.go
+++ b/e2e/script/main.go
@@ -22,6 +22,7 @@ const verifyCustomTokenURL = "https://www.googleapis.com/identitytoolkit/v3/rely
 type User struct {
 	UserToken1 string `yaml:"userToken1"`
 	UserToken2 string `yaml:"userToken2"`
+	UserToken3 string `yaml:"userToken3"`
 }
 
 type LoginYaml struct {
@@ -57,9 +58,15 @@ func main() {
 		log.Fatalf("error minting custom token: %v\n", err)
 	}
 
+	idToken3, err := makeUser(client, ctx, "e2e-delete-user")
+	if err != nil {
+		log.Fatalf("error minting custom token: %v\n", err)
+	}
+
 	ly := LoginYaml{}
 	ly.Vars.UserToken1 = idToken1
 	ly.Vars.UserToken2 = idToken2
+	ly.Vars.UserToken3 = idToken3
 
 	if err := WriteOnFile("./login.yaml", ly); err != nil {
 		log.Fatalf("WriteOnFile: %v\n", err)

--- a/e2e/simulator/.gitignore
+++ b/e2e/simulator/.gitignore
@@ -6,7 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 firebase-debug.log*
 firebase-debug.*.log*
-
 # Firebase cache
 .firebase/
 

--- a/e2e/user.yaml
+++ b/e2e/user.yaml
@@ -20,6 +20,7 @@ steps:
             id: "{{vars.userID}}"
             isNewUser: true
     expect:
+      code: 200
       body:
         data:
           createAuthUser:
@@ -43,6 +44,7 @@ steps:
           }
         variables:
     expect:
+      code: 200
       body:
         data:
           user:
@@ -66,6 +68,7 @@ steps:
           }
         variables:
     expect:
+      code: 200
       body:
         data:
           existAuthUser:
@@ -92,6 +95,7 @@ steps:
             displayName: test-name
             image: https://placehold.jp/150x150.png
     expect:
+      code: 200
       body:
         data:
           updateUser:
@@ -117,6 +121,7 @@ steps:
           }
         variables:
     expect:
+      code: 200
       body:
         data:
           user:

--- a/e2e/user3.yaml
+++ b/e2e/user3.yaml
@@ -1,0 +1,10 @@
+title: ユーザー3
+steps:
+  - title: login
+    include: "./login.yaml"
+    bind:
+      vars:
+        userToken: "{{vars.userToken3}}"
+        userID: "e2e-delete-user"
+  - title: ユーザーの操作
+    include: "./user.yaml"

--- a/graph/invite_test.go
+++ b/graph/invite_test.go
@@ -37,20 +37,15 @@ func TestCreateInvite(t *testing.T) {
 		g := newGraph(ctx)
 
 		inviteRepositoryMock := &moq_repository.InviteRepositoryInterfaceMock{
-			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Invite) error {
+			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.Invite) error {
 				return nil
 			},
 			FindByUserIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error) {
 				return param.Invite, nil
 			},
 		}
-		commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-			CommitFunc: func(ctx context.Context, batch *firestore.BulkWriter) {
-			},
-		}
 
 		g.App.InviteRepository = inviteRepositoryMock
-		g.App.CommonRepository = commonRepositoryMock
 
 		return g
 	}
@@ -131,10 +126,10 @@ func TestUpdateInvite(t *testing.T) {
 	g := newGraph(ctx)
 
 	inviteRepositoryMock := &moq_repository.InviteRepositoryInterfaceMock{
-		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Invite) error {
+		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.Invite) error {
 			return nil
 		},
-		DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, code string) error {
+		DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, code string) error {
 			return nil
 		},
 		FindByUserIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (*model.Invite, error) {
@@ -145,13 +140,7 @@ func TestUpdateInvite(t *testing.T) {
 		},
 	}
 
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(ctx context.Context, batch *firestore.BulkWriter) {
-		},
-	}
-
 	g.App.InviteRepository = inviteRepositoryMock
-	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string

--- a/graph/relationship_request_test.go
+++ b/graph/relationship_request_test.go
@@ -145,7 +145,7 @@ func TestAcceptRelationshipRequest(t *testing.T) {
 	g := newGraph(ctx)
 
 	relationshipRequestRepositoryMock := &moq_repository.RelationshipRequestInterfaceMock{
-		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error {
+		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.RelationshipRequest) error {
 			return nil
 		},
 		FindFunc: func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error) {
@@ -153,12 +153,8 @@ func TestAcceptRelationshipRequest(t *testing.T) {
 		},
 	}
 	relationshipRepositoryMock := &moq_repository.RelationshipInterfaceMock{
-		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+		CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.Relationship) error {
 			return nil
-		},
-	}
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(ctx context.Context, batch *firestore.BulkWriter) {
 		},
 	}
 	pushTokenRepositoryMock := &moq_repository.PushTokenRepositoryInterfaceMock{
@@ -174,7 +170,6 @@ func TestAcceptRelationshipRequest(t *testing.T) {
 
 	g.App.RelationshipRequestRepository = relationshipRequestRepositoryMock
 	g.App.RelationshipRepository = relationshipRepositoryMock
-	g.App.CommonRepository = commonRepositoryMock
 	g.App.UserRepository = userRepositoryMock
 	g.App.PushTokenRepository = pushTokenRepositoryMock
 
@@ -227,17 +222,12 @@ func TestNgRelationshipRequest(t *testing.T) {
 	g := newGraph(ctx)
 
 	relationshipRequestRepositoryMock := &moq_repository.RelationshipRequestInterfaceMock{
-		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error {
+		UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.RelationshipRequest) error {
 			return nil
-		},
-	}
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(ctx context.Context, batch *firestore.BulkWriter) {
 		},
 	}
 
 	g.App.RelationshipRequestRepository = relationshipRequestRepositoryMock
-	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string

--- a/graph/relationship_test.go
+++ b/graph/relationship_test.go
@@ -29,17 +29,12 @@ func TestDeleteRelationship(t *testing.T) {
 	g := newGraph(ctx)
 
 	relationshipRepositoryMock := &moq_repository.RelationshipInterfaceMock{
-		DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+		DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.Transaction, i *model.Relationship) error {
 			return nil
-		},
-	}
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(ctx context.Context, batch *firestore.BulkWriter) {
 		},
 	}
 
 	g.App.RelationshipRepository = relationshipRepositoryMock
-	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string

--- a/graph/user.go
+++ b/graph/user.go
@@ -147,8 +147,11 @@ func (g *Graph) DeleteUser(ctx context.Context) (*model.User, error) {
 			return err
 		}
 		if g.FirebaseUID != "" {
-			if err := g.App.AuthUseCase.DeleteAuthUser(ctx, g.FirestoreClient, g.FirebaseUID); err != nil {
-				return err
+			// e2eのダミーユーザーの場合は削除しない
+			if uid != "e2e-delete-user" {
+				if err := g.App.AuthUseCase.DeleteAuthUser(ctx, g.FirestoreClient, g.FirebaseUID); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/graph/user_test.go
+++ b/graph/user_test.go
@@ -26,7 +26,7 @@ type contextKey struct {
 
 type __ = context.Context
 type ___ = *firestore.Client
-type ____ = *firestore.BulkWriter
+type ____ = *firestore.Transaction
 
 func TestUpdateUser(t *testing.T) {
 	t.Parallel()
@@ -326,18 +326,12 @@ func TestDeleteUser(t *testing.T) {
 		},
 	}
 
-	commonRepositoryMock := &moq_repository.CommonRepositoryInterfaceMock{
-		CommitFunc: func(_ __, _ ____) {
-		},
-	}
-
 	g.App.RelationshipRepository = relationshipMock
 	g.App.AuthRepository = authRepositoryMock
 	g.App.UserRepository = userRepositoryMock
 	g.App.InviteRepository = inviteRepositoryMock
 	g.App.RelationshipRequestRepository = relationshipRequestMock
 	g.App.AuthUseCase = authMock
-	g.App.CommonRepository = commonRepositoryMock
 
 	tests := []struct {
 		name   string

--- a/repository/auth.go
+++ b/repository/auth.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 
 	"cloud.google.com/go/firestore"
 	ce "github.com/wheatandcat/memoir-backend/usecase/custom_error"
@@ -11,7 +10,7 @@ import (
 //go:generate moq -out=moq/auth.go -pkg=moqs . AuthRepositoryInterface
 
 type AuthRepositoryInterface interface {
-	Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error
+	Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error
 }
 
 type Auth struct {
@@ -26,16 +25,10 @@ func NewAuthRepository() AuthRepositoryInterface {
 }
 
 // Delete Authを削除する
-func (re *AuthRepository) Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error {
+func (re *AuthRepository) Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error {
 	ref := f.Collection("auth").Doc(uid)
-	j, err := batch.Delete(ref)
+	err := tx.Delete(ref)
 	if err != nil {
-		return ce.CustomError(err)
-	}
-	if j == nil {
-		return ce.CustomError(fmt.Errorf("BulkWriter: got nil"))
-	}
-	if _, err := j.Results(); err != nil {
 		return ce.CustomError(err)
 	}
 	return nil

--- a/repository/moq/auth.go
+++ b/repository/moq/auth.go
@@ -20,7 +20,7 @@ var _ repository.AuthRepositoryInterface = &AuthRepositoryInterfaceMock{}
 //
 //		// make and configure a mocked repository.AuthRepositoryInterface
 //		mockedAuthRepositoryInterface := &AuthRepositoryInterfaceMock{
-//			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error {
+//			DeleteFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error {
 //				panic("mock out the Delete method")
 //			},
 //		}
@@ -31,7 +31,7 @@ var _ repository.AuthRepositoryInterface = &AuthRepositoryInterfaceMock{}
 //	}
 type AuthRepositoryInterfaceMock struct {
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error
+	DeleteFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -41,8 +41,8 @@ type AuthRepositoryInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// UID is the uid argument value.
 			UID string
 		}
@@ -51,25 +51,25 @@ type AuthRepositoryInterfaceMock struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *AuthRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error {
+func (mock *AuthRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error {
 	if mock.DeleteFunc == nil {
 		panic("AuthRepositoryInterfaceMock.DeleteFunc: method is nil but AuthRepositoryInterface.Delete was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		UID   string
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		UID string
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		UID:   uid,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		UID: uid,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(ctx, f, batch, uid)
+	return mock.DeleteFunc(ctx, f, tx, uid)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
@@ -77,16 +77,16 @@ func (mock *AuthRepositoryInterfaceMock) Delete(ctx context.Context, f *firestor
 //
 //	len(mockedAuthRepositoryInterface.DeleteCalls())
 func (mock *AuthRepositoryInterfaceMock) DeleteCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	UID   string
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	UID string
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		UID   string
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		UID string
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete

--- a/repository/moq/invite.go
+++ b/repository/moq/invite.go
@@ -21,13 +21,13 @@ var _ repository.InviteRepositoryInterface = &InviteRepositoryInterfaceMock{}
 //
 //		// make and configure a mocked repository.InviteRepositoryInterface
 //		mockedInviteRepositoryInterface := &InviteRepositoryInterfaceMock{
-//			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Invite) error {
+//			CreateFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Invite) error {
 //				panic("mock out the Create method")
 //			},
-//			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, code string) error {
+//			DeleteFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, code string) error {
 //				panic("mock out the Delete method")
 //			},
-//			DeleteByUserIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+//			DeleteByUserIDFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 //				panic("mock out the DeleteByUserID method")
 //			},
 //			FindFunc: func(ctx context.Context, f *firestore.Client, code string) (*model.Invite, error) {
@@ -44,13 +44,13 @@ var _ repository.InviteRepositoryInterface = &InviteRepositoryInterfaceMock{}
 //	}
 type InviteRepositoryInterfaceMock struct {
 	// CreateFunc mocks the Create method.
-	CreateFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Invite) error
+	CreateFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Invite) error
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, code string) error
+	DeleteFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, code string) error
 
 	// DeleteByUserIDFunc mocks the DeleteByUserID method.
-	DeleteByUserIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error
+	DeleteByUserIDFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error
 
 	// FindFunc mocks the Find method.
 	FindFunc func(ctx context.Context, f *firestore.Client, code string) (*model.Invite, error)
@@ -66,8 +66,8 @@ type InviteRepositoryInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// I is the i argument value.
 			I *model.Invite
 		}
@@ -77,8 +77,8 @@ type InviteRepositoryInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// Code is the code argument value.
 			Code string
 		}
@@ -88,8 +88,8 @@ type InviteRepositoryInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// UserID is the userID argument value.
 			UserID string
 		}
@@ -120,25 +120,25 @@ type InviteRepositoryInterfaceMock struct {
 }
 
 // Create calls CreateFunc.
-func (mock *InviteRepositoryInterfaceMock) Create(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Invite) error {
+func (mock *InviteRepositoryInterfaceMock) Create(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Invite) error {
 	if mock.CreateFunc == nil {
 		panic("InviteRepositoryInterfaceMock.CreateFunc: method is nil but InviteRepositoryInterface.Create was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Invite
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Invite
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		I:     i,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		I:   i,
 	}
 	mock.lockCreate.Lock()
 	mock.calls.Create = append(mock.calls.Create, callInfo)
 	mock.lockCreate.Unlock()
-	return mock.CreateFunc(ctx, f, batch, i)
+	return mock.CreateFunc(ctx, f, tx, i)
 }
 
 // CreateCalls gets all the calls that were made to Create.
@@ -146,16 +146,16 @@ func (mock *InviteRepositoryInterfaceMock) Create(ctx context.Context, f *firest
 //
 //	len(mockedInviteRepositoryInterface.CreateCalls())
 func (mock *InviteRepositoryInterfaceMock) CreateCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	I     *model.Invite
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	I   *model.Invite
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Invite
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Invite
 	}
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create
@@ -164,25 +164,25 @@ func (mock *InviteRepositoryInterfaceMock) CreateCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *InviteRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, code string) error {
+func (mock *InviteRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, code string) error {
 	if mock.DeleteFunc == nil {
 		panic("InviteRepositoryInterfaceMock.DeleteFunc: method is nil but InviteRepositoryInterface.Delete was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		Code  string
+		Ctx  context.Context
+		F    *firestore.Client
+		Tx   *firestore.Transaction
+		Code string
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		Code:  code,
+		Ctx:  ctx,
+		F:    f,
+		Tx:   tx,
+		Code: code,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(ctx, f, batch, code)
+	return mock.DeleteFunc(ctx, f, tx, code)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
@@ -190,16 +190,16 @@ func (mock *InviteRepositoryInterfaceMock) Delete(ctx context.Context, f *firest
 //
 //	len(mockedInviteRepositoryInterface.DeleteCalls())
 func (mock *InviteRepositoryInterfaceMock) DeleteCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	Code  string
+	Ctx  context.Context
+	F    *firestore.Client
+	Tx   *firestore.Transaction
+	Code string
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		Code  string
+		Ctx  context.Context
+		F    *firestore.Client
+		Tx   *firestore.Transaction
+		Code string
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete
@@ -208,25 +208,25 @@ func (mock *InviteRepositoryInterfaceMock) DeleteCalls() []struct {
 }
 
 // DeleteByUserID calls DeleteByUserIDFunc.
-func (mock *InviteRepositoryInterfaceMock) DeleteByUserID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+func (mock *InviteRepositoryInterfaceMock) DeleteByUserID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 	if mock.DeleteByUserIDFunc == nil {
 		panic("InviteRepositoryInterfaceMock.DeleteByUserIDFunc: method is nil but InviteRepositoryInterface.DeleteByUserID was just called")
 	}
 	callInfo := struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}{
 		Ctx:    ctx,
 		F:      f,
-		Batch:  batch,
+		Tx:     tx,
 		UserID: userID,
 	}
 	mock.lockDeleteByUserID.Lock()
 	mock.calls.DeleteByUserID = append(mock.calls.DeleteByUserID, callInfo)
 	mock.lockDeleteByUserID.Unlock()
-	return mock.DeleteByUserIDFunc(ctx, f, batch, userID)
+	return mock.DeleteByUserIDFunc(ctx, f, tx, userID)
 }
 
 // DeleteByUserIDCalls gets all the calls that were made to DeleteByUserID.
@@ -236,13 +236,13 @@ func (mock *InviteRepositoryInterfaceMock) DeleteByUserID(ctx context.Context, f
 func (mock *InviteRepositoryInterfaceMock) DeleteByUserIDCalls() []struct {
 	Ctx    context.Context
 	F      *firestore.Client
-	Batch  *firestore.BulkWriter
+	Tx     *firestore.Transaction
 	UserID string
 } {
 	var calls []struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}
 	mock.lockDeleteByUserID.RLock()

--- a/repository/moq/relationship.go
+++ b/repository/moq/relationship.go
@@ -21,10 +21,10 @@ var _ repository.RelationshipInterface = &RelationshipInterfaceMock{}
 //
 //		// make and configure a mocked repository.RelationshipInterface
 //		mockedRelationshipInterface := &RelationshipInterfaceMock{
-//			CreateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+//			CreateFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error {
 //				panic("mock out the Create method")
 //			},
-//			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+//			DeleteFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error {
 //				panic("mock out the Delete method")
 //			},
 //			ExistByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string) (bool, error) {
@@ -41,10 +41,10 @@ var _ repository.RelationshipInterface = &RelationshipInterfaceMock{}
 //	}
 type RelationshipInterfaceMock struct {
 	// CreateFunc mocks the Create method.
-	CreateFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error
+	CreateFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error
+	DeleteFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error
 
 	// ExistByFollowedIDFunc mocks the ExistByFollowedID method.
 	ExistByFollowedIDFunc func(ctx context.Context, f *firestore.Client, userID string) (bool, error)
@@ -60,8 +60,8 @@ type RelationshipInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// I is the i argument value.
 			I *model.Relationship
 		}
@@ -71,8 +71,8 @@ type RelationshipInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// I is the i argument value.
 			I *model.Relationship
 		}
@@ -106,25 +106,25 @@ type RelationshipInterfaceMock struct {
 }
 
 // Create calls CreateFunc.
-func (mock *RelationshipInterfaceMock) Create(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+func (mock *RelationshipInterfaceMock) Create(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error {
 	if mock.CreateFunc == nil {
 		panic("RelationshipInterfaceMock.CreateFunc: method is nil but RelationshipInterface.Create was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Relationship
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Relationship
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		I:     i,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		I:   i,
 	}
 	mock.lockCreate.Lock()
 	mock.calls.Create = append(mock.calls.Create, callInfo)
 	mock.lockCreate.Unlock()
-	return mock.CreateFunc(ctx, f, batch, i)
+	return mock.CreateFunc(ctx, f, tx, i)
 }
 
 // CreateCalls gets all the calls that were made to Create.
@@ -132,16 +132,16 @@ func (mock *RelationshipInterfaceMock) Create(ctx context.Context, f *firestore.
 //
 //	len(mockedRelationshipInterface.CreateCalls())
 func (mock *RelationshipInterfaceMock) CreateCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	I     *model.Relationship
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	I   *model.Relationship
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Relationship
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Relationship
 	}
 	mock.lockCreate.RLock()
 	calls = mock.calls.Create
@@ -150,25 +150,25 @@ func (mock *RelationshipInterfaceMock) CreateCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *RelationshipInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.Relationship) error {
+func (mock *RelationshipInterfaceMock) Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.Relationship) error {
 	if mock.DeleteFunc == nil {
 		panic("RelationshipInterfaceMock.DeleteFunc: method is nil but RelationshipInterface.Delete was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Relationship
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Relationship
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		I:     i,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		I:   i,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(ctx, f, batch, i)
+	return mock.DeleteFunc(ctx, f, tx, i)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
@@ -176,16 +176,16 @@ func (mock *RelationshipInterfaceMock) Delete(ctx context.Context, f *firestore.
 //
 //	len(mockedRelationshipInterface.DeleteCalls())
 func (mock *RelationshipInterfaceMock) DeleteCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	I     *model.Relationship
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	I   *model.Relationship
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.Relationship
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.Relationship
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete

--- a/repository/moq/relationship_request.go
+++ b/repository/moq/relationship_request.go
@@ -24,10 +24,10 @@ var _ repository.RelationshipRequestInterface = &RelationshipRequestInterfaceMoc
 //			CreateFunc: func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) error {
 //				panic("mock out the Create method")
 //			},
-//			DeleteByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+//			DeleteByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 //				panic("mock out the DeleteByFollowedID method")
 //			},
-//			DeleteByFollowerIDFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+//			DeleteByFollowerIDFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 //				panic("mock out the DeleteByFollowerID method")
 //			},
 //			FindFunc: func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error) {
@@ -36,7 +36,7 @@ var _ repository.RelationshipRequestInterface = &RelationshipRequestInterfaceMoc
 //			FindByFollowedIDFunc: func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipRequestCursor) ([]*model.RelationshipRequest, error) {
 //				panic("mock out the FindByFollowedID method")
 //			},
-//			UpdateFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error {
+//			UpdateFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.RelationshipRequest) error {
 //				panic("mock out the Update method")
 //			},
 //		}
@@ -50,10 +50,10 @@ type RelationshipRequestInterfaceMock struct {
 	CreateFunc func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) error
 
 	// DeleteByFollowedIDFunc mocks the DeleteByFollowedID method.
-	DeleteByFollowedIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error
+	DeleteByFollowedIDFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error
 
 	// DeleteByFollowerIDFunc mocks the DeleteByFollowerID method.
-	DeleteByFollowerIDFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error
+	DeleteByFollowerIDFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error
 
 	// FindFunc mocks the Find method.
 	FindFunc func(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error)
@@ -62,7 +62,7 @@ type RelationshipRequestInterfaceMock struct {
 	FindByFollowedIDFunc func(ctx context.Context, f *firestore.Client, userID string, first int, cursor repository.RelationshipRequestCursor) ([]*model.RelationshipRequest, error)
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error
+	UpdateFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.RelationshipRequest) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -81,8 +81,8 @@ type RelationshipRequestInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// UserID is the userID argument value.
 			UserID string
 		}
@@ -92,8 +92,8 @@ type RelationshipRequestInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// UserID is the userID argument value.
 			UserID string
 		}
@@ -125,8 +125,8 @@ type RelationshipRequestInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// I is the i argument value.
 			I *model.RelationshipRequest
 		}
@@ -180,25 +180,25 @@ func (mock *RelationshipRequestInterfaceMock) CreateCalls() []struct {
 }
 
 // DeleteByFollowedID calls DeleteByFollowedIDFunc.
-func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 	if mock.DeleteByFollowedIDFunc == nil {
 		panic("RelationshipRequestInterfaceMock.DeleteByFollowedIDFunc: method is nil but RelationshipRequestInterface.DeleteByFollowedID was just called")
 	}
 	callInfo := struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}{
 		Ctx:    ctx,
 		F:      f,
-		Batch:  batch,
+		Tx:     tx,
 		UserID: userID,
 	}
 	mock.lockDeleteByFollowedID.Lock()
 	mock.calls.DeleteByFollowedID = append(mock.calls.DeleteByFollowedID, callInfo)
 	mock.lockDeleteByFollowedID.Unlock()
-	return mock.DeleteByFollowedIDFunc(ctx, f, batch, userID)
+	return mock.DeleteByFollowedIDFunc(ctx, f, tx, userID)
 }
 
 // DeleteByFollowedIDCalls gets all the calls that were made to DeleteByFollowedID.
@@ -208,13 +208,13 @@ func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedID(ctx context.Con
 func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedIDCalls() []struct {
 	Ctx    context.Context
 	F      *firestore.Client
-	Batch  *firestore.BulkWriter
+	Tx     *firestore.Transaction
 	UserID string
 } {
 	var calls []struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}
 	mock.lockDeleteByFollowedID.RLock()
@@ -224,25 +224,25 @@ func (mock *RelationshipRequestInterfaceMock) DeleteByFollowedIDCalls() []struct
 }
 
 // DeleteByFollowerID calls DeleteByFollowerIDFunc.
-func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 	if mock.DeleteByFollowerIDFunc == nil {
 		panic("RelationshipRequestInterfaceMock.DeleteByFollowerIDFunc: method is nil but RelationshipRequestInterface.DeleteByFollowerID was just called")
 	}
 	callInfo := struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}{
 		Ctx:    ctx,
 		F:      f,
-		Batch:  batch,
+		Tx:     tx,
 		UserID: userID,
 	}
 	mock.lockDeleteByFollowerID.Lock()
 	mock.calls.DeleteByFollowerID = append(mock.calls.DeleteByFollowerID, callInfo)
 	mock.lockDeleteByFollowerID.Unlock()
-	return mock.DeleteByFollowerIDFunc(ctx, f, batch, userID)
+	return mock.DeleteByFollowerIDFunc(ctx, f, tx, userID)
 }
 
 // DeleteByFollowerIDCalls gets all the calls that were made to DeleteByFollowerID.
@@ -252,13 +252,13 @@ func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerID(ctx context.Con
 func (mock *RelationshipRequestInterfaceMock) DeleteByFollowerIDCalls() []struct {
 	Ctx    context.Context
 	F      *firestore.Client
-	Batch  *firestore.BulkWriter
+	Tx     *firestore.Transaction
 	UserID string
 } {
 	var calls []struct {
 		Ctx    context.Context
 		F      *firestore.Client
-		Batch  *firestore.BulkWriter
+		Tx     *firestore.Transaction
 		UserID string
 	}
 	mock.lockDeleteByFollowerID.RLock()
@@ -356,25 +356,25 @@ func (mock *RelationshipRequestInterfaceMock) FindByFollowedIDCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *RelationshipRequestInterfaceMock) Update(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error {
+func (mock *RelationshipRequestInterfaceMock) Update(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.RelationshipRequest) error {
 	if mock.UpdateFunc == nil {
 		panic("RelationshipRequestInterfaceMock.UpdateFunc: method is nil but RelationshipRequestInterface.Update was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.RelationshipRequest
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.RelationshipRequest
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		I:     i,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		I:   i,
 	}
 	mock.lockUpdate.Lock()
 	mock.calls.Update = append(mock.calls.Update, callInfo)
 	mock.lockUpdate.Unlock()
-	return mock.UpdateFunc(ctx, f, batch, i)
+	return mock.UpdateFunc(ctx, f, tx, i)
 }
 
 // UpdateCalls gets all the calls that were made to Update.
@@ -382,16 +382,16 @@ func (mock *RelationshipRequestInterfaceMock) Update(ctx context.Context, f *fir
 //
 //	len(mockedRelationshipRequestInterface.UpdateCalls())
 func (mock *RelationshipRequestInterfaceMock) UpdateCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	I     *model.RelationshipRequest
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	I   *model.RelationshipRequest
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		I     *model.RelationshipRequest
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		I   *model.RelationshipRequest
 	}
 	mock.lockUpdate.RLock()
 	calls = mock.calls.Update

--- a/repository/moq/user.go
+++ b/repository/moq/user.go
@@ -24,7 +24,7 @@ var _ repository.UserRepositoryInterface = &UserRepositoryInterfaceMock{}
 //			CreateFunc: func(ctx context.Context, f *firestore.Client, u *model.User) error {
 //				panic("mock out the Create method")
 //			},
-//			DeleteFunc: func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error {
+//			DeleteFunc: func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error {
 //				panic("mock out the Delete method")
 //			},
 //			ExistByFirebaseUIDFunc: func(ctx context.Context, f *firestore.Client, fUID string) (bool, error) {
@@ -59,7 +59,7 @@ type UserRepositoryInterfaceMock struct {
 	CreateFunc func(ctx context.Context, f *firestore.Client, u *model.User) error
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error
+	DeleteFunc func(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error
 
 	// ExistByFirebaseUIDFunc mocks the ExistByFirebaseUID method.
 	ExistByFirebaseUIDFunc func(ctx context.Context, f *firestore.Client, fUID string) (bool, error)
@@ -99,8 +99,8 @@ type UserRepositoryInterfaceMock struct {
 			Ctx context.Context
 			// F is the f argument value.
 			F *firestore.Client
-			// Batch is the batch argument value.
-			Batch *firestore.BulkWriter
+			// Tx is the tx argument value.
+			Tx *firestore.Transaction
 			// UID is the uid argument value.
 			UID string
 		}
@@ -220,25 +220,25 @@ func (mock *UserRepositoryInterfaceMock) CreateCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *UserRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, uid string) error {
+func (mock *UserRepositoryInterfaceMock) Delete(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, uid string) error {
 	if mock.DeleteFunc == nil {
 		panic("UserRepositoryInterfaceMock.DeleteFunc: method is nil but UserRepositoryInterface.Delete was just called")
 	}
 	callInfo := struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		UID   string
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		UID string
 	}{
-		Ctx:   ctx,
-		F:     f,
-		Batch: batch,
-		UID:   uid,
+		Ctx: ctx,
+		F:   f,
+		Tx:  tx,
+		UID: uid,
 	}
 	mock.lockDelete.Lock()
 	mock.calls.Delete = append(mock.calls.Delete, callInfo)
 	mock.lockDelete.Unlock()
-	return mock.DeleteFunc(ctx, f, batch, uid)
+	return mock.DeleteFunc(ctx, f, tx, uid)
 }
 
 // DeleteCalls gets all the calls that were made to Delete.
@@ -246,16 +246,16 @@ func (mock *UserRepositoryInterfaceMock) Delete(ctx context.Context, f *firestor
 //
 //	len(mockedUserRepositoryInterface.DeleteCalls())
 func (mock *UserRepositoryInterfaceMock) DeleteCalls() []struct {
-	Ctx   context.Context
-	F     *firestore.Client
-	Batch *firestore.BulkWriter
-	UID   string
+	Ctx context.Context
+	F   *firestore.Client
+	Tx  *firestore.Transaction
+	UID string
 } {
 	var calls []struct {
-		Ctx   context.Context
-		F     *firestore.Client
-		Batch *firestore.BulkWriter
-		UID   string
+		Ctx context.Context
+		F   *firestore.Client
+		Tx  *firestore.Transaction
+		UID string
 	}
 	mock.lockDelete.RLock()
 	calls = mock.calls.Delete

--- a/repository/relationship_request.go
+++ b/repository/relationship_request.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -22,9 +21,9 @@ const (
 
 type RelationshipRequestInterface interface {
 	Create(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) error
-	Update(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error
-	DeleteByFollowedID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error
-	DeleteByFollowerID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error
+	Update(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.RelationshipRequest) error
+	DeleteByFollowedID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error
+	DeleteByFollowerID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error
 	Find(ctx context.Context, f *firestore.Client, i *model.RelationshipRequest) (*model.RelationshipRequest, error)
 	FindByFollowedID(ctx context.Context, f *firestore.Client, userID string, first int, cursor RelationshipRequestCursor) ([]*model.RelationshipRequest, error)
 }
@@ -66,7 +65,7 @@ func (re *RelationshipRequestRepository) Create(ctx context.Context, f *firestor
 }
 
 // Update 更新する
-func (re *RelationshipRequestRepository) Update(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, i *model.RelationshipRequest) error {
+func (re *RelationshipRequestRepository) Update(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, i *model.RelationshipRequest) error {
 	var u []firestore.Update
 	if i.Status != 0 {
 		u = append(u, firestore.Update{Path: "Status", Value: i.Status})
@@ -74,21 +73,15 @@ func (re *RelationshipRequestRepository) Update(ctx context.Context, f *firestor
 	u = append(u, firestore.Update{Path: "UpdatedAt", Value: i.UpdatedAt})
 
 	ref := f.Collection("relationshipRequests").Doc(i.FollowerID + "_" + i.FollowedID)
-	j, err := batch.Update(ref, u)
+	err := tx.Update(ref, u)
 	if err != nil {
-		return ce.CustomError(err)
-	}
-	if j == nil {
-		return ce.CustomError(fmt.Errorf("BulkWriter: got nil"))
-	}
-	if _, err := j.Results(); err != nil {
 		return ce.CustomError(err)
 	}
 	return nil
 }
 
 // DeleteByFollowedID ユーザーIDから削除する
-func (re *RelationshipRequestRepository) DeleteByFollowedID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+func (re *RelationshipRequestRepository) DeleteByFollowedID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 	matchItem := f.Collection("relationshipRequests").Where("FollowedID", "==", userID).OrderBy("CreatedAt", firestore.Desc).Documents(ctx)
 	docs, err := matchItem.GetAll()
 
@@ -101,14 +94,8 @@ func (re *RelationshipRequestRepository) DeleteByFollowedID(ctx context.Context,
 	}
 
 	for _, doc := range docs {
-		j, err := batch.Delete(doc.Ref)
+		err := tx.Delete(doc.Ref)
 		if err != nil {
-			return ce.CustomError(err)
-		}
-		if j == nil {
-			return ce.CustomError(fmt.Errorf("BulkWriter: got nil"))
-		}
-		if _, err := j.Results(); err != nil {
 			return ce.CustomError(err)
 		}
 	}
@@ -117,7 +104,7 @@ func (re *RelationshipRequestRepository) DeleteByFollowedID(ctx context.Context,
 }
 
 // DeleteByFollowerID ユーザーIDから削除する
-func (re *RelationshipRequestRepository) DeleteByFollowerID(ctx context.Context, f *firestore.Client, batch *firestore.BulkWriter, userID string) error {
+func (re *RelationshipRequestRepository) DeleteByFollowerID(ctx context.Context, f *firestore.Client, tx *firestore.Transaction, userID string) error {
 	matchItem := f.Collection("relationshipRequests").Where("FollowerID", "==", userID).OrderBy("CreatedAt", firestore.Desc).Documents(ctx)
 	docs, err := matchItem.GetAll()
 
@@ -130,14 +117,8 @@ func (re *RelationshipRequestRepository) DeleteByFollowerID(ctx context.Context,
 	}
 
 	for _, doc := range docs {
-		j, err := batch.Delete(doc.Ref)
+		err := tx.Delete(doc.Ref)
 		if err != nil {
-			return ce.CustomError(err)
-		}
-		if j == nil {
-			return ce.CustomError(fmt.Errorf("BulkWriter: got nil"))
-		}
-		if _, err := j.Results(); err != nil {
 			return ce.CustomError(err)
 		}
 	}


### PR DESCRIPTION
## 関連 issue

- fixes #160 

## 対応内容

- 元々、1つの処理内でfirestoreに複数件の書き込みをしている箇所は、バッチ書き込みで同時に書き込み処理を実行していた
  - [バッチ書き込み](https://firebase.google.com/docs/firestore/manage-data/transactions)
- Firestore SDKの[v1.9.0](https://pkg.go.dev/cloud.google.com/go/firestore/apiv1beta1?tab=versions)からfirestore.WriteBatchが非推奨になって、firestore.BulkWriterへの移行が推奨になった
- ただ、firestore.BulkWriterは大量のドキュメントを書き込む処理に特化した機能になっており、現状の利用用途に合わなくなった
- なので、Firestore.BulkWriterからRunTransactionに移行
  -  [トランザクションによるデータの更新](https://firebase.google.com/docs/firestore/manage-data/transactions)

## 開発用メモ
無し

